### PR TITLE
Refactor: deprecate redux-thunk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2827,15 +2827,6 @@
         }
       }
     },
-    "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
-      "requires": {
-        "caller-callsite": "^2.0.0"
-      }
-    },
     "camel-case": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
@@ -7963,14 +7954,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -7992,7 +7983,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -8018,7 +8009,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -8048,16 +8039,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -8106,7 +8097,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -8126,12 +8117,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -8196,17 +8187,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -8224,35 +8215,35 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -8269,13 +8260,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -8352,12 +8343,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -8387,16 +8378,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -8414,7 +8405,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -8467,17 +8458,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -8488,12 +8479,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -8503,7 +8494,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -11713,9 +11704,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -15251,11 +15242,6 @@
       "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-1.0.0.tgz",
       "integrity": "sha512-6bXnpqWTBeLaLQjXHyN1giXq4nLxCmv+SUkdmiwBgvmVxvDbdmydvL1Z7DGo0WItyzI/kqXQKiucUuTxnrPRkA=="
     },
-    "redux-thunk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -15552,12 +15538,6 @@
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       }
-    },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "dev": true
     },
     "resolve-global": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "react-load-script": "0.0.6",
     "redux": "^4.0.0",
     "redux-observable": "^1.0.0-beta.2",
-    "redux-thunk": "^2.2.0",
     "rxjs": "^6.1.0",
     "rxjs-compat": "^6.1.0",
     "simple-color-scale": "^1.0.1",

--- a/plugins/lime-plugin-admin/src/adminActions.js
+++ b/plugins/lime-plugin-admin/src/adminActions.js
@@ -3,16 +3,13 @@ import {
 	AUTH_LOGIN
 } from './adminConstants';
 
-export const adminLogin = (credentials) => (dispatch) => {
-	dispatch({
-		type: AUTH_LOGIN,
-		payload: credentials
-	});
-};
+export const adminLogin = (credentials) => ({
+	type: AUTH_LOGIN,
+	payload: credentials
+});
 
-export const changeConfig = (config) => (dispatch) => {
-	dispatch({
-		type: SET_CONFIG,
-		payload: config
-	});
-};
+
+export const changeConfig = (config) => ({
+	type: SET_CONFIG,
+	payload: config
+});

--- a/plugins/lime-plugin-align/src/alignActions.js
+++ b/plugins/lime-plugin-align/src/alignActions.js
@@ -4,37 +4,34 @@ import {
 	IFACES_LOAD,
 	TIMER_STOP
 } from './alignConstants';
+import { store } from '../../../src/store';
 
-export const changeInterface = (iface) => (dispatch, getState) => {
-	if (iface === getState().align.currentReading.iface) {
-		return;
+export const changeInterface = (iface) => {
+	if (iface === store.getState().align.currentReading.iface) {
+		return { type: 'no_iface' };
 	}
-	dispatch({
+	return {
 		type: IFACE_CHANGE,
 		payload: {
 			iface
 		}
-	});
+	};
 };
 
-export const changeStation = (mac) => (dispatch, getState) => {
-	if (mac === getState().align.currentReading.mac) {
-		return;
+export const changeStation = (mac) => {
+	if (mac === store.getState().align.currentReading.mac) {
+		return { type: 'no_change' };
 	}
-	dispatch({
+	return {
 		type: STATION_SET,
-		payload: getState().align.stations.filter(x => x.mac === mac)[0]
-	});
+		payload: store.getState().align.stations.filter(x => x.mac === mac)[0]
+	};
 };
 
-export const startAlign = () => (dispatch) => {
-	dispatch({
-		type: IFACES_LOAD
-	});
-};
+export const startAlign = () => ({
+	type: IFACES_LOAD
+});
 
-export const stopTimer = () => (dispatch) => {
-	dispatch({
-		type: TIMER_STOP
-	});
-};
+export const stopTimer = () => ({
+	type: TIMER_STOP
+});

--- a/plugins/lime-plugin-core/src/metaActions.js
+++ b/plugins/lime-plugin-core/src/metaActions.js
@@ -2,15 +2,16 @@ import {
 	TOGGLE_MENU_BUTTON
 } from './metaConstants';
 
-export const changeBase = ( hostname ) => (dispatch, getState) => {
+export const changeBase = ( hostname ) => {
 	if (typeof window !== 'undefined') {
 		window.location.href = 'http://'+ hostname +'/app';
 	}
+	return {
+		type: '__CHANGE_BASE'
+	};
 };
 
-export const toggleMenuButton = (option) => (dispatch) => {
-	dispatch({
-		type: TOGGLE_MENU_BUTTON,
-		payload: option
-	});
-};
+export const toggleMenuButton = (option) => ({
+	type: TOGGLE_MENU_BUTTON,
+	payload: option
+});

--- a/plugins/lime-plugin-fbw/src/actions.js
+++ b/plugins/lime-plugin-fbw/src/actions.js
@@ -5,38 +5,30 @@ import {
 	FBW_STATUS
 } from './constants';
 
-export const searchNetworks = ( rescan ) => ( dispatch ) => {
-	dispatch({
-		type: FBW_SEARCH_NETWORKS,
-		payload: {
-			rescan
-		}
-	});
-};
+export const searchNetworks = ( rescan ) => ({
+	type: FBW_SEARCH_NETWORKS,
+	payload: {
+		rescan
+	}
+});
 
-export const setNetwork = ({ file, network, hostname }) => ( dispatch ) => {
-	dispatch({
-		type: FBW_SET_NETWORK,
-		payload: {
-			file,
-			network,
-			hostname
-		}
-	});
-};
+export const setNetwork = ({ file, network, hostname }) => ({
+	type: FBW_SET_NETWORK,
+	payload: {
+		file,
+		network,
+		hostname
+	}
+});
 
-export const createNetwork = ({ network, hostname }) => ( dispatch ) => {
-	dispatch({
-		type: FBW_CREATE_NETWORK,
-		payload: {
-			network,
-			hostname
-		}
-	});
-};
+export const createNetwork = ({ network, hostname }) => ({
+	type: FBW_CREATE_NETWORK,
+	payload: {
+		network,
+		hostname
+	}
+});
 
-export const getStatus = () => ( dispatch ) => {
-	dispatch({
-		type: FBW_STATUS
-	});
-};
+export const getStatus = () => ({
+	type: FBW_STATUS
+});

--- a/plugins/lime-plugin-ground-routing/src/groundRoutingActions.js
+++ b/plugins/lime-plugin-ground-routing/src/groundRoutingActions.js
@@ -3,15 +3,12 @@ import {
 	GROUNDROUTING_SET
 } from './groundRoutingConstants';
 
-export const getGroundRouting = () => (dispatch) => {
-	dispatch({
-		type: GROUNDROUTING_GET
-	});
-};
+export const getGroundRouting = () => ({
+	type: GROUNDROUTING_GET
+});
 
-export const setGroundRouting = (config) => (dispatch) => {
-	dispatch({
-		type: GROUNDROUTING_SET,
-		payload: { config }
-	});
-};
+
+export const setGroundRouting = (config) => ({
+	type: GROUNDROUTING_SET,
+	payload: { config }
+});

--- a/plugins/lime-plugin-locate/src/locateActions.js
+++ b/plugins/lime-plugin-locate/src/locateActions.js
@@ -5,28 +5,21 @@ import {
 	LOCATION_USER_SET
 } from './locateConstants';
 
-export const loadLocationLinks = ( ) => (dispatch, getState) => {
-	dispatch({
-		type: LOCATION_LOAD_LINKS
-	});
-};
+export const loadLocationLinks = ( ) => ({
+	type: LOCATION_LOAD_LINKS
+});
 
-export const loadLocation = ( ) => (dispatch, getState) => {
-	dispatch({
-		type: LOCATION_LOAD
-	});
-};
 
-export const changeLocation = ( location ) => (dispatch, getState) => {
-	dispatch({
-		type: LOCATION_CHANGE,
-		payload: location
-	});
-};
+export const loadLocation = ( ) => ({
+	type: LOCATION_LOAD
+});
 
-export const setUserLocation = (location) => (dispatch) => {
-	dispatch({
-		type: LOCATION_USER_SET,
-		payload: location
-	});
-};
+export const changeLocation = ( location ) => ({
+	type: LOCATION_CHANGE,
+	payload: location
+});
+
+export const setUserLocation = (location) => ({
+	type: LOCATION_USER_SET,
+	payload: location
+});

--- a/plugins/lime-plugin-metrics/src/metricsActions.js
+++ b/plugins/lime-plugin-metrics/src/metricsActions.js
@@ -1,5 +1,3 @@
-import { push } from 'preact-router-redux';
-
 import {
 	LOAD_METRICS,
 	LOAD_METRICS_ALL
@@ -9,26 +7,19 @@ import {
 	GET_INTERNET_STATUS
 } from '../../lime-plugin-rx/src/rxConstants';
 
-export const getMetrics = ( ) => (dispatch) => {
-	dispatch({
-		type: LOAD_METRICS
-	});
-	dispatch({
-		type: GET_INTERNET_STATUS
-	});
-};
+export const getMetrics = ( ) => ({
+	type: LOAD_METRICS
+});
 
-export const getMetricsAll = ( ) => (dispatch) => {
-	dispatch({
-		type: LOAD_METRICS_ALL
-	});
-};
 
-export const getMetricsGateway = ( hostname ) => (dispatch) => {
-	dispatch({
-		type: LOAD_METRICS
-	});
-	dispatch({
-		type: GET_INTERNET_STATUS
-	});
-};
+export const getMetricsAll = ( ) => ({
+	type: LOAD_METRICS_ALL
+});
+
+export const getInternetStatus = () => ({
+	type: GET_INTERNET_STATUS
+});
+
+export const getMetricsGateway = ( ) => ({
+	type: LOAD_METRICS
+});

--- a/plugins/lime-plugin-metrics/src/metricsPage.js
+++ b/plugins/lime-plugin-metrics/src/metricsPage.js
@@ -3,7 +3,7 @@ import { h, Component } from 'preact';
 import { bindActionCreators } from 'redux';
 import { connect } from 'preact-redux';
 
-import { getMetrics, getMetricsAll, getMetricsGateway } from './metricsActions';
+import { getInternetStatus, getMetrics, getMetricsAll, getMetricsGateway } from './metricsActions';
 import { getNodeData, getSettings } from '../../lime-plugin-rx/src/rxSelectors';
 
 import Loading from '../../../src/components/loading';
@@ -56,6 +56,7 @@ class Metrics extends Component {
 	clickGateway(gateway) {
 		return () => {
 			this.props.getMetricsGateway(gateway);
+			this.props.getInternetStatus();
 		};
 	}
 
@@ -147,6 +148,7 @@ class Metrics extends Component {
   
 	componentWillMount() {
 		this.props.getMetrics();
+		this.props.getInternetStatus();
 		colorScale.setConfig({
 			outputStart: 1,
 			outputEnd: 100,
@@ -182,7 +184,8 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
 	getMetrics: bindActionCreators(getMetrics,dispatch),
 	getMetricsGateway: bindActionCreators(getMetricsGateway,dispatch),
-	getMetricsAll: bindActionCreators(getMetricsAll,dispatch)
+	getMetricsAll: bindActionCreators(getMetricsAll,dispatch),
+	getInternetStatus: bindActionCreators(getInternetStatus, dispatch)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Metrics);

--- a/plugins/lime-plugin-notes/src/notesActions.js
+++ b/plugins/lime-plugin-notes/src/notesActions.js
@@ -3,15 +3,11 @@ import {
 	NOTES_SET
 } from './notesConstants';
 
-export const getNotes = () => (dispatch) => {
-	dispatch({
-		type: NOTES_GET
-	});
-};
+export const getNotes = () => ({
+	type: NOTES_GET
+});
 
-export const setNotes = (notes) => (dispatch) => {
-	dispatch({
-		type: NOTES_SET,
-		payload: { notes }
-	});
-};
+export const setNotes = (notes) => ({
+	type: NOTES_SET,
+	payload: { notes }
+});

--- a/plugins/lime-plugin-rx/src/rxActions.js
+++ b/plugins/lime-plugin-rx/src/rxActions.js
@@ -6,26 +6,23 @@ import {
 
 import { push } from 'preact-router-redux';
 
-export const getNodeStatus = () => (dispatch) => {
-	dispatch({
-		type: GET_NODE_STATUS,
-		payload: {}
-	});
-};
+export const getNodeStatus = () => ({
+	type: GET_NODE_STATUS,
+	payload: {}
+});
 
-export const getNodeStatusTimer =  () => (dispatch) => {
-	getNodeStatus()(dispatch);
-	dispatch({
-		type: TIMER_START,
-		payload: {}
-	});
-};
-export const stopTimer = () => (dispatch) => {
-	dispatch({
-		type: TIMER_STOP
-	});
-};
+export const getNodeStatusTimer =  () => ({
+	type: TIMER_START,
+	payload: {}
+});
 
-export const changeNode = (hostname) => (dispatch) => {
-	dispatch(push('changeNode/'+hostname));
+export const stopTimer = () => ({
+	type: TIMER_STOP
+});
+
+export const changeNode = (hostname) => {
+	console.log(push('changeNode/'+hostname));
+	return {
+		type: 'change_base'
+	};
 };

--- a/plugins/lime-plugin-rx/src/rxPage.js
+++ b/plugins/lime-plugin-rx/src/rxPage.js
@@ -3,7 +3,7 @@ import { h, Component } from 'preact';
 import { bindActionCreators } from 'redux';
 import { connect } from 'preact-redux';
 
-import { getNodeStatusTimer, stopTimer, changeNode } from './rxActions';
+import { getNodeStatusTimer, stopTimer, changeNode, getNodeStatus } from './rxActions';
 import { getNodeData, isLoading } from './rxSelectors';
 
 import { Box } from '../../../src/components/box';
@@ -124,6 +124,7 @@ export class Page extends Component {
 	}
 
 	componentDidMount() {
+		this.props.getNodeStatusTimer();
 		this.props.getNodeStatus();
 	}
 
@@ -148,7 +149,8 @@ export const mapStateToProps = (state) => ({
 });
 
 export const mapDispatchToProps = (dispatch) => ({
-	getNodeStatus: bindActionCreators(getNodeStatusTimer,dispatch),
+	getNodeStatusTimer: bindActionCreators(getNodeStatusTimer,dispatch),
+	getNodeStatus: bindActionCreators(getNodeStatus,dispatch),
 	stopTimer: bindActionCreators(stopTimer,dispatch),
 	changeNode: bindActionCreators(changeNode,dispatch)
 });

--- a/src/components/banner/index.js
+++ b/src/components/banner/index.js
@@ -2,6 +2,7 @@ import { h, Component } from 'preact';
 import { connect } from 'preact-redux';
 import style from './style';
 import I18n from 'i18n-js';
+import { bindActionCreators } from 'redux';
 class Banner extends Component {
 
 	onOk(){
@@ -47,6 +48,6 @@ export default connect(
 		banner: state.meta.banner || false
 	}),
 	(dispatch) => ({
-		send: (action) => dispatch(action)
+		send: bindActionCreators((action) => action, dispatch)
 	})
 )(Banner);

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -73,21 +73,22 @@ const mapStateToProps = (state) => ({
 	isBanner: isBanner(state)
 });
 
-const goBase = (hostname) => (dispatch) => {
-	dispatch({
-		type: 'meta/CONECTION_CHANGE_URL',
-		payload: 'http://thisnode.info/ubus'
-	});
-};
+const goBase = (hostname) => ({
+	type: 'meta/CONECTION_CHANGE_URL',
+	payload: 'http://thisnode.info/ubus'
+});
 
-const hideAlert = () => (dispatch) => {
-	dispatch({
-		type: 'NOTIFICATION_HIDE'
-	});
-};
 
-const changeNode = (hostname) => (dispatch) => {
+const hideAlert = () => ({
+	type: 'NOTIFICATION_HIDE'
+});
+
+const changeNode = (hostname) => {
 	window.location.href = 'http://'+hostname;
+	return {
+		type: '__CHANGE_NODE',
+		payload: hostname
+	};
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,15 @@ import 'skeleton-less/less/skeleton';
 
 import 'preact/devtools';
 
-import store from './store';
+import store, { initStore } from './store';
 
 import App from './containers/app';
 
 import { history } from './store/history';
 
 import './i18nline-glue';
+
+initStore();
 
 // in development, set up HMR:
 if (module.hot) {

--- a/src/store.js
+++ b/src/store.js
@@ -20,9 +20,9 @@ const rootReducers = combineReducers(reducers);
 const rootEpics =  combineEpics(...loadEpics(plugins));
 
 //CREATE STORE
-const store = createStore({},rootEpics,rootReducers, new UhttpdService());
+export const store = createStore({},rootEpics,rootReducers, new UhttpdService());
 
 // Init websocket
-store.dispatch({ type: 'meta/CONECTION_START', payload: window.location.href.split('/').slice(0, 3).join('/').concat('/ubus' ) });
+export const initStore = () => store.dispatch({ type: 'meta/CONECTION_START', payload: 'http://10.5.0.1/ubus' });
 
 export default store;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,7 +1,4 @@
-export const showNotification = (msg) => (dispatch) => {
-	dispatch({
-		type: 'NOTIFICATION',
-		payload: { msg }
-	});
-};
-
+export const showNotification = (msg) => ({
+	type: 'NOTIFICATION',
+	payload: { msg }
+});

--- a/src/store/createStore.js
+++ b/src/store/createStore.js
@@ -1,6 +1,4 @@
 import { compose, createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
-
 import { createEpicMiddleware } from 'redux-observable';
 import { routerMiddleware } from 'preact-router-redux';
 
@@ -18,7 +16,7 @@ export default (initialState,rootEpics,rootReducers, wsAPI) => {
 	});
 
 	const enhancer = composeEnhancers(
-		applyMiddleware(...[reduxRouterMiddleware,epicMiddleware,thunk.withExtraArgument()]),
+		applyMiddleware(...[reduxRouterMiddleware,epicMiddleware]),
 	);
 
 	const store = createStore(rootReducers, initialState, enhancer);


### PR DESCRIPTION
To simplify the lime-app code this pull-request removes redux-thunk as middelware and updates the actions so that now are synchronous