### PR TITLE
Make the default be a relative path

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -10,5 +10,5 @@ require('dotenv').config();
  **/
 export default function (config, env, helpers) {
 	// Basepath of lime-app in the router: http://thisnode.info/app/
-	config.output.publicPath = process.env.WEB_PATH || '/';
+	config.output.publicPath = process.env.WEB_PATH || '';
 }


### PR DESCRIPTION
# What is happening

In the case you don't define WEB_PATH, the app assumes that will be located in the root of the webserver.

# What is expected to happen

In the case you don't define WEB_PATH, for the app to use relative path to be located in any place.