### PR TITLE
Add shared password input in network creation form.

### DIFF
--- a/plugins/lime-plugin-fbw/src/actions.js
+++ b/plugins/lime-plugin-fbw/src/actions.js
@@ -21,11 +21,12 @@ export const setNetwork = ({ file, network, hostname }) => ({
 	}
 });
 
-export const createNetwork = ({ network, hostname }) => ({
+export const createNetwork = ({ network, hostname, password }) => ({
 	type: FBW_CREATE_NETWORK,
 	payload: {
 		network,
-		hostname
+		hostname,
+		password
 	}
 });
 

--- a/plugins/lime-plugin-fbw/src/actions.js
+++ b/plugins/lime-plugin-fbw/src/actions.js
@@ -21,12 +21,12 @@ export const setNetwork = ({ file, network, hostname }) => ({
 	}
 });
 
-export const createNetwork = ({ network, hostname, password }) => ({
+export const createNetwork = ({ network, hostname, adminPassword }) => ({
 	type: FBW_CREATE_NETWORK,
 	payload: {
 		network,
 		hostname,
-		password
+		adminPassword
 	}
 });
 

--- a/plugins/lime-plugin-fbw/src/api.js
+++ b/plugins/lime-plugin-fbw/src/api.js
@@ -7,5 +7,5 @@ export const searchNetworks = (api, sid, rescan) =>
 export const setNetwork = (api, sid, { file, hostname }) =>
     api.call(sid, 'lime-fbw', 'set_network', { file, hostname });
 
-export const createNetwork = (api, sid, { network, hostname, password }) =>
-    api.call(sid, 'lime-fbw', 'create_network', { network, hostname, password });
+export const createNetwork = (api, sid, { network, hostname, adminPassword }) =>
+    api.call(sid, 'lime-fbw', 'create_network', { network, hostname, adminPassword });

--- a/plugins/lime-plugin-fbw/src/api.js
+++ b/plugins/lime-plugin-fbw/src/api.js
@@ -4,5 +4,5 @@ export const searchNetworks = (api, sid, rescan) => api.call(sid, 'lime-fbw', 's
 
 export const setNetwork = (api, sid, { file, hostname }) => api.call(sid, 'lime-fbw', 'set_network', { file, hostname });
 
-// network -> { name: String }
-export const createNetwork = (api, sid, { network, hostname } ) => api.call(sid, 'lime-fbw', 'create_network', { network, hostname });
+export const createNetwork = (api, sid, { network, hostname, password } ) =>
+    api.call(sid, 'lime-fbw', 'create_network', { network, hostname, password });

--- a/plugins/lime-plugin-fbw/src/api.js
+++ b/plugins/lime-plugin-fbw/src/api.js
@@ -1,8 +1,11 @@
-export const getStatus = (api, sid) => api.call(sid, 'lime-fbw', 'status', {});
+export const getStatus = (api, sid) =>
+    api.call(sid, 'lime-fbw', 'status', {});
 
-export const searchNetworks = (api, sid, rescan) => api.call(sid, 'lime-fbw', 'search_networks', { scan: rescan || false });
+export const searchNetworks = (api, sid, rescan) =>
+    api.call(sid, 'lime-fbw', 'search_networks', { scan: rescan || false });
 
-export const setNetwork = (api, sid, { file, hostname }) => api.call(sid, 'lime-fbw', 'set_network', { file, hostname });
+export const setNetwork = (api, sid, { file, hostname }) =>
+    api.call(sid, 'lime-fbw', 'set_network', { file, hostname });
 
-export const createNetwork = (api, sid, { network, hostname, password } ) =>
+export const createNetwork = (api, sid, { network, hostname, password }) =>
     api.call(sid, 'lime-fbw', 'create_network', { network, hostname, password });

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -12,48 +12,72 @@ import I18n from 'i18n-js';
 import { isValidHostname, slugify } from '../../../../src/utils/isValidHostname';
 
 export const NetworkForm = ({ createNetwork, toggleForm }) => {
-	const [ state, setState ] = useState({
+	const [state, setState] = useState({
 		communityName: '',
 		hostName: '',
-		password: ''
+		password: '',
+		passwordConfirmation: '',
 	});
 
-	function _changeName (e) {
+	function _changeName(e) {
 		const end = e.type === 'change';
 		e.target.value = slugify(e.target.value.toLocaleLowerCase(), end, true);
 		setState({ ...state, communityName: e.target.value || '' });
 		return e;
 	}
 
-	function _changeHostName (e) {
+	function _changeHostName(e) {
 		const end = e.type === 'change';
 		e.target.value = slugify(e.target.value, end);
 		setState({ ...state, hostName: e.target.value || '' });
 		return e;
 	}
 
-	/* function _changePassword (e){
-		setState({ ...stat, password: e.target.value || '' });
-	} */
+	function _changePassword(e) {
+		setState({ ...state, password: e.target.value || '' });
+		return e;
+	}
 
-	function _createNetwork(){
-		createNetwork({ network: state.communityName, hostname: state.hostName });
+	function _changePasswordConfirmation(e) {
+		setState({ ...state, passwordConfirmation: e.target.value || '' });
+		return e;
+	}
+
+	function _createNetwork() {
+		createNetwork({
+			network: state.communityName,
+			hostname: state.hostName,
+			password: state.password,
+		});
 		toggleForm('setting')();
+	}
+
+	function _isValidPassword() {
+		return state.password.length > 0;
+	}
+
+	function _passwordMissMatch() {
+		return state.password && state.passwordConfirmation && state.password !== state.passwordConfirmation;
 	}
 
 	return (<div class="container" style={{ paddingTop: '100px' }}>
 		<h4><span>{I18n.t('Configure your new community network')}</span></h4>
 		<label>{I18n.t('Choose a name for your network')}</label>
 		<input type="text" placeholder={I18n.t('Community name')} class="u-full-width" onChange={_changeName} onInput={_changeName} />
+		<label>{I18n.t('Choose a shared password for network adminitration')}</label>
+		<input type="password" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onChange={_changePassword} onInput={_changePassword} />
+		<label>{I18n.t('Re-enter the shared password')}</label>
+		<input type="password" placeholder={I18n.t('Re-enter Password')} class="u-full-width" value={state.passwordConfirmation} onChange={_changePasswordConfirmation} onInput={_changePasswordConfirmation} />
+		{_passwordMissMatch() &&
+			<label>{I18n.t('The passwords do not match!')}</label>
+		}
 		<label>{I18n.t('Choose a name for this node')}</label>
 		<input type="text" placeholder={I18n.t('Host name')} class="u-full-width" value={state.hostName} onChange={_changeHostName} onInput={_changeHostName} />
-		{/* <label>{I18n.t('Choose a password for this node')}</label>
-		<input type="text" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onChange={_changePassword} /> */}
 		<div class="row">
 			<div class="six columns">
 				<button
 					class="u-full-width"
-					disabled={!isValidHostname(state.communityName,true) || !isValidHostname(state.hostName, true)}
+					disabled={!_isValidPassword() || _passwordMissMatch() || !isValidHostname(state.communityName, true) || !isValidHostname(state.hostName, true)}
 					onClick={_createNetwork}
 				>
 					{I18n.t('Create network')}
@@ -74,7 +98,7 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 const mapStateToProps = (state) => ({});
 
 const mapDispatchToProps = (dispatch) => ({
-	createNetwork: bindActionCreators(createNetwork ,dispatch)
+	createNetwork: bindActionCreators(createNetwork, dispatch)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NetworkForm);

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -63,16 +63,16 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 	return (<div class="container" style={{ paddingTop: '100px' }}>
 		<h4><span>{I18n.t('Configure your new community network')}</span></h4>
 		<label>{I18n.t('Choose a name for your network')}</label>
-		<input type="text" placeholder={I18n.t('Community name')} class="u-full-width" onChange={_changeName} onInput={_changeName} />
+		<input type="text" placeholder={I18n.t('Community name')} class="u-full-width" onInput={_changeName} />
 		<label>{I18n.t('Choose a shared password for network adminitration')}</label>
-		<input type="password" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onChange={_changePassword} onInput={_changePassword} />
+		<input type="password" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onInput={_changePassword} />
 		<label>{I18n.t('Re-enter the shared password')}</label>
-		<input type="password" placeholder={I18n.t('Re-enter Password')} class="u-full-width" value={state.passwordConfirmation} onChange={_changePasswordConfirmation} onInput={_changePasswordConfirmation} />
+		<input type="password" placeholder={I18n.t('Re-enter Password')} class="u-full-width" value={state.passwordConfirmation} onInput={_changePasswordConfirmation} />
 		{_passwordMissMatch() &&
 			<label>{I18n.t('The passwords do not match!')}</label>
 		}
 		<label>{I18n.t('Choose a name for this node')}</label>
-		<input type="text" placeholder={I18n.t('Host name')} class="u-full-width" value={state.hostName} onChange={_changeHostName} onInput={_changeHostName} />
+		<input type="text" placeholder={I18n.t('Host name')} class="u-full-width" value={state.hostName} onInput={_changeHostName} />
 		<div class="row">
 			<div class="six columns">
 				<button

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -11,6 +11,16 @@ import { createNetwork } from '../actions';
 import I18n from 'i18n-js';
 import { isValidHostname, slugify } from '../../../../src/utils/isValidHostname';
 
+const StatusBox = ({value}) => (
+	<b>
+		{value ?
+			(<span style={{ color: 'green' }}>✔</span>)
+			:
+			(<span style={{ color: 'red' }}>✘</span>)
+		}
+	</b>
+)
+
 export const NetworkForm = ({ createNetwork, toggleForm }) => {
 	const [state, setState] = useState({
 		communityName: '',
@@ -52,8 +62,26 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 		toggleForm('setting')();
 	}
 
+	function _PasswordHasLength() {
+		// Check there is at least 10 characters in the string
+		return state.password.match("^(?=.{10,}$).*$")
+	}
+
+	function _PasswordHasNumber() {
+		// Check there is at least one number in the string
+		return state.password.match("^(?=.*[0-9]).*$")
+	}
+
+	function _PasswordHasAlphanumeric() {
+		// Check there is at least one alphanumeric in the string
+		return state.password.match("^(?=.*[a-zA-z]).*$")
+	}
 	function _isValidPassword() {
-		return state.password.length > 0;
+		return (
+			_PasswordHasLength() &&
+			_PasswordHasAlphanumeric() &&
+			_PasswordHasNumber()
+		);
 	}
 
 	function _passwordMatch() {
@@ -75,10 +103,15 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 		<input type="text" placeholder={I18n.t('Community name')} class="u-full-width" onInput={_changeName} />
 		<label>{I18n.t('Choose a shared password for network adminitration')}</label>
 		<input type="password" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onInput={_changePassword} />
+		<p>{I18n.t('The password should have:')}<br />
+			<StatusBox value={_PasswordHasLength()} /> {I18n.t('More than 10 characters')}<br />
+			<StatusBox value={_PasswordHasNumber()} /> {I18n.t('At least one number')}<br />
+			<StatusBox value={_PasswordHasAlphanumeric()} /> {I18n.t('At least one alphanumeric character')}<br />
+		</p>
 		<label>{I18n.t('Re-enter the shared password')}</label>
 		<input type="password" placeholder={I18n.t('Re-enter Password')} class="u-full-width" value={state.passwordConfirmation} onInput={_changePasswordConfirmation} />
 		{state.passwordConfirmation && !_passwordMatch() &&
-			<label>{I18n.t('The passwords do not match!')}</label>
+			<p>{I18n.t('The passwords do not match!')}</p>
 		}
 		<label>{I18n.t('Choose a name for this node')}</label>
 		<input type="text" placeholder={I18n.t('Host name')} class="u-full-width" value={state.hostName} onInput={_changeHostName} />

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -56,8 +56,17 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 		return state.password.length > 0;
 	}
 
-	function _passwordMissMatch() {
-		return state.password && state.passwordConfirmation && state.password !== state.passwordConfirmation;
+	function _passwordMatch() {
+		return state.password === state.passwordConfirmation;
+	}
+
+	function _isValidForm() {
+		return (
+			_isValidPassword() &&
+			_passwordMatch() &&
+			isValidHostname(state.communityName, true) &&
+			isValidHostname(state.hostName, true)
+		)
 	}
 
 	return (<div class="container" style={{ paddingTop: '100px' }}>
@@ -68,7 +77,7 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 		<input type="password" placeholder={I18n.t('Password')} class="u-full-width" value={state.password} onInput={_changePassword} />
 		<label>{I18n.t('Re-enter the shared password')}</label>
 		<input type="password" placeholder={I18n.t('Re-enter Password')} class="u-full-width" value={state.passwordConfirmation} onInput={_changePasswordConfirmation} />
-		{_passwordMissMatch() &&
+		{state.passwordConfirmation && !_passwordMatch() &&
 			<label>{I18n.t('The passwords do not match!')}</label>
 		}
 		<label>{I18n.t('Choose a name for this node')}</label>
@@ -77,7 +86,7 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 			<div class="six columns">
 				<button
 					class="u-full-width"
-					disabled={!_isValidPassword() || _passwordMissMatch() || !isValidHostname(state.communityName, true) || !isValidHostname(state.hostName, true)}
+					disabled={!_isValidForm()}
 					onClick={_createNetwork}
 				>
 					{I18n.t('Create network')}

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -57,7 +57,7 @@ export const NetworkForm = ({ createNetwork, toggleForm }) => {
 		createNetwork({
 			network: state.communityName,
 			hostname: state.hostName,
-			password: state.password,
+			adminPassword: state.password,
 		});
 		toggleForm('setting')();
 	}


### PR DESCRIPTION
This PR adds the input at FBW for setting a up the shared-password described at #237.

The password is sent to ubus endpoint lime-fbw -> create_network along with the network and host names.

closes #237 