### PR TITLE
improvement(rxpage): show human readable uptime

### DIFF
--- a/i18n/generic.json
+++ b/i18n/generic.json
@@ -23,6 +23,22 @@
     "confirm_location_2fe5ae11": "confirm location",
     "congratulations_ffe43bf9": "Congratulations",
     "connected_host_91e11459": "Connected Host",
+    "count_days_de0c6a32": {
+      "one": "1 days",
+      "other": "%{count} days"
+    },
+    "count_hours_1bd03883": {
+      "one": "1 hours",
+      "other": "%{count} hours"
+    },
+    "count_minutes_a6eeeacb": {
+      "one": "1 minutes",
+      "other": "%{count} minutes"
+    },
+    "count_seconds_2953a98e": {
+      "one": "1 seconds",
+      "other": "%{count} seconds"
+    },
     "create_network_d229d642": "Create network",
     "create_new_network_28805f92": "Create new network",
     "current_status_830c5a75": "Current status",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -38,5 +38,21 @@
   "uptime_c1d2415d" :"Uptime",
   "interfaces_44f8a99c": "Interfaces",
   "last_known_internet_path_45f31c9a": "This your last working path to the Internet",
-  "you_should_try_to_connect_to_the_network_network_8d7f515e": "You should try to connect to the wifi network %{network}."
+  "you_should_try_to_connect_to_the_network_network_8d7f515e": "You should try to connect to the wifi network %{network}.",
+  "count_days_de0c6a32": {
+    "one": "day",
+    "other": "days"
+  },
+  "count_hours_1bd03883": {
+      "one": "hour",
+      "other": "hours"
+  },
+  "count_minutes_a6eeeacb": {
+      "one": "minute",
+      "other": "minutes"
+  },
+  "count_seconds_2953a98e": {
+      "one": "second",
+      "other": "seconds"
+  }
 }

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -134,6 +134,22 @@
     "try_reloading_the_app_4e4c3a66": "Intentar recargar la app",
     "when_reloading_the_app_you_will_be_asked_to_confir_f9ecb33e": "Al recargar la aplicación, se te pedirá que confirmes la actualización, si no lo haces se revertirá",
     "please_select_a_file_b49d6bf4": "Porfavor, elige un archivo",
-    "device_95d26d94": "Equipo"
+    "device_95d26d94": "Equipo",
+    "count_days_de0c6a32": {
+        "one": "día",
+        "other": "días"
+    },
+    "count_hours_1bd03883": {
+        "one": "hora",
+        "other": "horas"
+    },
+    "count_minutes_a6eeeacb": {
+        "one": "minuto",
+        "other": "minutos"
+    },
+    "count_seconds_2953a98e": {
+        "one": "segundo",
+        "other": "segundos"
+    }
 }
 

--- a/plugins/lime-plugin-rx/rx.stories.js
+++ b/plugins/lime-plugin-rx/rx.stories.js
@@ -36,7 +36,7 @@ const nodeData =  {
 	],
 	hostname: 'ql-anaymarcos',
 	status: 'ok',
-	uptime: '6655.80\n',
+	uptime: '93055.80\n',
 	most_active: {
 	  rx_bytes: 82509781,
 	  station_mac: 'A8:40:41:1C:84:05',

--- a/plugins/lime-plugin-rx/src/rxPage.js
+++ b/plugins/lime-plugin-rx/src/rxPage.js
@@ -15,15 +15,18 @@ function stripIface (hostIface) {
 	return hostIface.split('_wlan')[0].replace('_','-');
 }
 
-const toHHMMSS = (secs, plus) => {
-	let secNum = parseInt(secs, 10) + plus;
-	let days    = Math.floor(secNum / 86400) % 24;
-	let hours   = Math.floor(secNum / 3600) % 24;
-	let minutes = Math.floor(secNum / 60) % 60;
-	let seconds = secNum % 60;
-	return [days,hours,minutes,seconds]
-		.map(v => v < 10 ? '0' + v : v)
-		.join(':');
+const toHHMMSS = (seconds, plus) => {
+	let secNum = parseInt(seconds, 10) + plus;
+	let days = Math.floor(secNum / 86400) % 24;
+	let hours = Math.floor(secNum / 3600) % 24;
+	let mins = Math.floor(secNum / 60) % 60;
+	let secs = secNum % 60;
+	const daysText = days ? [days, I18n.t('days', { count: days })].join(' ') : null;
+	const hoursText = hours ? [hours, I18n.t('hours', { count: hours })].join(' ') : null;
+	const minsText = mins ? [mins, I18n.t('minutes', { count: mins })].join(' ') : null;
+	const secsText = secs ? [secs, I18n.t('seconds', { count: secs })].join(' ') : null;
+	const allTexts = [daysText, hoursText, minsText, secsText];
+	return allTexts.filter(x => x !== null).join(', ');
 };
 
 const SystemBox = ({ uptime, firmwareVersion, boardModel }) => {

--- a/plugins/lime-plugin-rx/src/rxPage.js
+++ b/plugins/lime-plugin-rx/src/rxPage.js
@@ -17,7 +17,7 @@ function stripIface (hostIface) {
 
 const toHHMMSS = (seconds, plus) => {
 	let secNum = parseInt(seconds, 10) + plus;
-	let days = Math.floor(secNum / 86400) % 24;
+	let days = Math.floor(secNum / 86400);
 	let hours = Math.floor(secNum / 3600) % 24;
 	let mins = Math.floor(secNum / 60) % 60;
 	let secs = secNum % 60;


### PR DESCRIPTION
Now it looks like:

![Screenshot from 2020-09-05 13-09-40](https://user-images.githubusercontent.com/7140856/92309179-a6fe8200-ef79-11ea-8eec-16a89a658249.png)

Both spanish and english translations were added, with pluralization