### PR TITLE
improvement(node-config): reduce node config to hostname

### DIFF
--- a/plugins/lime-plugin-admin/admin.stories.js
+++ b/plugins/lime-plugin-admin/admin.stories.js
@@ -1,13 +1,13 @@
 /* eslint-disable react/display-name */
 import { h } from 'preact';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, object, text } from '@storybook/addon-knobs/react';
+import { withKnobs, text } from '@storybook/addon-knobs/react';
 
 import { Admin } from './src/adminPage';
 import { AppContext } from '../../src/utils/app.context';
 
 const actions = {
-	changeConfig: action('changeConfig')
+	changeHostname: action('changeHostname')
 };
 
 export default {
@@ -17,19 +17,12 @@ export default {
 };
 
 const nodeHostname = text('nodeHostname', 'ql-anaymarcos');
-const changeNode = action('changeNode');
 
 export const configForm = () => {
-	const appContext = { nodeHostname, changeNode };
+	const appContext = { nodeHostname };
 	return (
 		<AppContext.Provider value={appContext}>
 			<Admin
-				nodeData={object('Node data', {
-					ips: [{
-						version: '4',
-						address: '10.5.0.4'
-					}]
-				})}
 				loading={false}
 				{...actions}
 			/>
@@ -37,16 +30,10 @@ export const configForm = () => {
 };
 
 export const waitingForChanges = () => {
-	const appContext = { nodeHostname, changeNode };
+	const appContext = { nodeHostname };
 	return (
 		<AppContext.Provider value={appContext}>
 			<Admin
-				nodeData={object('Node data', {
-					ips: [{
-						version: '4',
-						address: '10.5.0.4'
-					}]
-				})}
 				loading
 				{...actions}
 			/>

--- a/plugins/lime-plugin-admin/src/adminActions.js
+++ b/plugins/lime-plugin-admin/src/adminActions.js
@@ -1,8 +1,8 @@
 import {
-	SET_CONFIG
+	SET_HOSTNAME
 } from './adminConstants';
 
-export const changeConfig = (config) => ({
-	type: SET_CONFIG,
-	payload: config
+export const changeHostname = (hostname) => ({
+	type: SET_HOSTNAME,
+	payload: hostname
 });

--- a/plugins/lime-plugin-admin/src/adminApi.js
+++ b/plugins/lime-plugin-admin/src/adminApi.js
@@ -1,2 +1,5 @@
 export const changeHostname = (api, hostname) =>
 	api.call('lime-utils-admin', 'set_hostname', { hostname });
+
+export const getIpV4 = (api) =>
+	api.call('lime-utils', 'get_node_status', {})

--- a/plugins/lime-plugin-admin/src/adminApi.js
+++ b/plugins/lime-plugin-admin/src/adminApi.js
@@ -1,2 +1,2 @@
-export const changeConfig = (api, config) =>
-	api.call('lime-utils', 'change_config', { hostname: config.hostname, ip: config.ip });
+export const changeHostname = (api, hostname) =>
+	api.call('lime-utils-admin', 'set_hostname', { hostname });

--- a/plugins/lime-plugin-admin/src/adminConstants.js
+++ b/plugins/lime-plugin-admin/src/adminConstants.js
@@ -1,5 +1,3 @@
-export const RELOAD_CONFIG = 'admin/RELOAD_CONFIG';
-
-export const SET_CONFIG = 'admin/SET_CONFIG';
-export const SET_CONFIG_SUCCESS = 'admin/SET_CONFIG_SUCCESS';
-export const SET_CONFIG_ERROR = 'admin/SET_CONFIG_ERROR';
+export const SET_HOSTNAME = 'admin/SET_HOSTNAME';
+export const SET_HOSTNAME_SUCCESS = 'admin/SET_HOSTNAME_SUCCESS';
+export const SET_HOSTNAME_ERROR = 'admin/SET_HOSTNAME_ERROR';

--- a/plugins/lime-plugin-admin/src/adminConstants.js
+++ b/plugins/lime-plugin-admin/src/adminConstants.js
@@ -1,3 +1,4 @@
 export const SET_HOSTNAME = 'admin/SET_HOSTNAME';
 export const SET_HOSTNAME_SUCCESS = 'admin/SET_HOSTNAME_SUCCESS';
 export const SET_HOSTNAME_ERROR = 'admin/SET_HOSTNAME_ERROR';
+export const GET_IP_SUCCESS = 'admin/GET_IP_SUCCESS';

--- a/plugins/lime-plugin-admin/src/adminEpics.js
+++ b/plugins/lime-plugin-admin/src/adminEpics.js
@@ -1,11 +1,13 @@
 import {
 	SET_HOSTNAME,
 	SET_HOSTNAME_SUCCESS,
-	SET_HOSTNAME_ERROR
+	SET_HOSTNAME_ERROR,
+	GET_IP_SUCCESS
 } from './adminConstants';
 
 import {
-	changeHostname
+	changeHostname,
+	getIpV4
 } from './adminApi';
 
 import { ofType } from 'redux-observable';
@@ -20,7 +22,15 @@ const setHostname = (action$, _store, { wsAPI }) =>
 		))
 	);
 
+const _getIpV4 = (action$, _store, { wsAPI }) =>
+	action$.pipe(
+		ofType(SET_HOSTNAME_SUCCESS),
+		mergeMap((action) => getIpV4(wsAPI, action.payload).pipe(
+			map( payload => ({ type: GET_IP_SUCCESS, payload }))
+		))
+	);
 
 export default {
-	setHostname
+	setHostname,
+	_getIpV4
 };

--- a/plugins/lime-plugin-admin/src/adminEpics.js
+++ b/plugins/lime-plugin-admin/src/adminEpics.js
@@ -1,27 +1,26 @@
 import {
-	RELOAD_CONFIG,
-	SET_CONFIG,
-	SET_CONFIG_SUCCESS,
-	SET_CONFIG_ERROR
+	SET_HOSTNAME,
+	SET_HOSTNAME_SUCCESS,
+	SET_HOSTNAME_ERROR
 } from './adminConstants';
 
 import {
-	changeConfig
+	changeHostname
 } from './adminApi';
 
 import { ofType } from 'redux-observable';
 import { mergeMap, map, catchError } from 'rxjs/operators';
 
-const setConfig = (action$, _store, { wsAPI }) =>
+const setHostname = (action$, _store, { wsAPI }) =>
 	action$.pipe(
-		ofType(SET_CONFIG),
-		mergeMap((action) => changeConfig(wsAPI, action.payload).pipe(
-			map( payload => ({ type: SET_CONFIG_SUCCESS, payload })),
-			catchError( error => ([{ type: SET_CONFIG_ERROR, payload: error }]) )
+		ofType(SET_HOSTNAME),
+		mergeMap((action) => changeHostname(wsAPI, action.payload).pipe(
+			map( payload => ({ type: SET_HOSTNAME_SUCCESS, payload })),
+			catchError( error => ([{ type: SET_HOSTNAME_ERROR, payload: error }]) )
 		))
 	);
 
 
 export default {
-	setConfig
+	setHostname
 };

--- a/plugins/lime-plugin-admin/src/adminPage.js
+++ b/plugins/lime-plugin-admin/src/adminPage.js
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'preact/hooks';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import { changeConfig } from './adminActions';
+import { changeHostname } from './adminActions';
 import { loading, redirect, error } from './adminSelectors';
 import { getNodeData } from '../../lime-plugin-rx/src/rxSelectors';
 
@@ -35,37 +35,25 @@ const style = {
 };
 
 
-export const Admin = ({ changeConfig, showNotification, nodeData, loading, redirect, error }) => {
-	const { nodeHostname, changeNode } = useAppContext();
-	const [ state, setState ] = useState({
-		hostname: nodeHostname,
-		ip: nodeData.ips.filter(ip => ip.version === '4')[0].address
-	});
+export const Admin = ({ changeHostname, showNotification, loading, redirect, error }) => {
+	const { nodeHostname } = useAppContext();
+	const [ hostname, setHostname ] = useState(nodeHostname);
 
 	useEffect(() => {
 		if (redirect) {
-			setTimeout(() => {
-				changeNode(state.hostname);
-			}, 60000);
+			window.location.href = 'http://'.concat(hostname);
 		}
-	}, [state.hostname, redirect, changeNode]);
+	}, [hostname, redirect]);
 
 	function handleHostname(e) {
 		const end = e.type === 'change';
-		e.target.value = slugify(e.target.value, end);
-		setState({ ...state, hostname: e.target.value });
-		return e;
+		setHostname(slugify(e.target.value, end));
 	}
 
-	function handleIp(e) {
-		setState({ ...state, ip: e.target.value });
-		return e;
-	}
-
-	function _changeConfig(e) {
+	function _changeHostname(e) {
 		e.preventDefault();
-		if (isValidHostname(state.hostname, true)) {
-			return changeConfig({ hostname: state.hostname, ip: state.ip });
+		if (isValidHostname(hostname, true)) {
+			return changeHostname(hostname);
 		}
 		showNotification('Invalid hostname, needs to be at least three characters long.');
 	}
@@ -75,7 +63,7 @@ export const Admin = ({ changeConfig, showNotification, nodeData, loading, redir
 			return (
 				<div style={style.loadingBox}>
 					<Loading />
-					<span style={style.textLoading}>{I18n.t('Applying changes. The system takes a minute to get back online.')}</span>
+					<span style={style.textLoading}>{I18n.t('Applying changes.')}</span>
 				</div>
 			);
 		}
@@ -84,14 +72,10 @@ export const Admin = ({ changeConfig, showNotification, nodeData, loading, redir
 	return (
 		<div className="container container-padded">
 			{showLoading(loading)}
-			<form onSubmit={_changeConfig}>
+			<form onSubmit={_changeHostname}>
 				<p>
 					<label>{I18n.t('Station name')}</label>
-					<input type="text" value={state.hostname} onInput={handleHostname} onChange={handleHostname} className="u-full-width" />
-				</p>
-				<p>
-					<label>{I18n.t('Station IP v4')}</label>
-					<input type="text" value={state.ip} onInput={handleIp} className="u-full-width" />
+					<input type="text" value={hostname} onInput={handleHostname} className="u-full-width" />
 				</p>
 				<button className="button block" type="submit">{I18n.t('Change')}</button>
 			</form>
@@ -109,7 +93,7 @@ export const mapStateToProps = (state) => ({
 });
 
 export const mapDispatchToProps = (dispatch) => ({
-	changeConfig: bindActionCreators(changeConfig, dispatch),
+	changeHostname: bindActionCreators(changeHostname, dispatch),
 	showNotification: bindActionCreators(showNotification, dispatch)
 });
 

--- a/plugins/lime-plugin-admin/src/adminPage.js
+++ b/plugins/lime-plugin-admin/src/adminPage.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import { changeHostname } from './adminActions';
-import { loading, redirect, error } from './adminSelectors';
+import { loading, redirect, error, ipv4 } from './adminSelectors';
 import { getNodeData } from '../../lime-plugin-rx/src/rxSelectors';
 
 import Loading from '../../../src/components/loading';
@@ -14,6 +14,7 @@ import I18n from 'i18n-js';
 import { isValidHostname, slugify } from '../../../src/utils/isValidHostname';
 import { showNotification } from '../../../src/store/actions';
 import { useAppContext } from '../../../src/utils/app.context';
+import axios from 'axios';
 
 const style = {
 	textLoading: {
@@ -35,15 +36,15 @@ const style = {
 };
 
 
-export const Admin = ({ changeHostname, showNotification, loading, redirect, error }) => {
+export const Admin = ({ ipv4, changeHostname, showNotification, loading, redirect, error }) => {
 	const { nodeHostname } = useAppContext();
 	const [ hostname, setHostname ] = useState(nodeHostname);
 
 	useEffect(() => {
 		if (redirect) {
-			window.location.href = 'http://'.concat(hostname);
+			window.location.href = 'http://'.concat(ipv4);
 		}
-	}, [hostname, redirect]);
+	}, [ipv4, redirect]);
 
 	function handleHostname(e) {
 		const end = e.type === 'change';
@@ -89,7 +90,8 @@ export const mapStateToProps = (state) => ({
 	nodeData: getNodeData(state),
 	loading: loading(state),
 	redirect: redirect(state),
-	error: error(state)
+	error: error(state),
+	ipv4: ipv4(state),
 });
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/plugins/lime-plugin-admin/src/adminReducer.js
+++ b/plugins/lime-plugin-admin/src/adminReducer.js
@@ -1,15 +1,20 @@
 import {
 	SET_HOSTNAME,
 	SET_HOSTNAME_ERROR,
-	SET_HOSTNAME_SUCCESS
+	GET_IP_SUCCESS
 } from './adminConstants';
 
 export const initialState = {
 	hostname: '',
 	loading: false,
 	redirect: false,
-	error: false
+	error: false,
+	ipv4: null
 };
+
+function parseIpv4(payload) {
+	return payload.ips.filter(x => x.version === "4")[0].address.split('/')[0]
+}
 
 export const reducer = (state = initialState, { type, payload }) => {
 	switch (type) {
@@ -17,8 +22,8 @@ export const reducer = (state = initialState, { type, payload }) => {
 			return Object.assign({}, state, { hostname: payload, loading: true });
 		case SET_HOSTNAME_ERROR:
 			return Object.assign({}, state, { loading: false, error: true });
-		case SET_HOSTNAME_SUCCESS:
-			return Object.assign({}, state, { redirect: true });
+		case GET_IP_SUCCESS:
+			return Object.assign({}, state, { ipv4: parseIpv4(payload), redirect: true });
 		default:
 			return state;
 	}

--- a/plugins/lime-plugin-admin/src/adminReducer.js
+++ b/plugins/lime-plugin-admin/src/adminReducer.js
@@ -1,8 +1,7 @@
 import {
-	RELOAD_CONFIG,
-	SET_CONFIG,
-	SET_CONFIG_ERROR,
-	SET_CONFIG_SUCCESS
+	SET_HOSTNAME,
+	SET_HOSTNAME_ERROR,
+	SET_HOSTNAME_SUCCESS
 } from './adminConstants';
 
 export const initialState = {
@@ -14,13 +13,11 @@ export const initialState = {
 
 export const reducer = (state = initialState, { type, payload }) => {
 	switch (type) {
-		case RELOAD_CONFIG:
-			return Object.assign({}, initialState);
-		case SET_CONFIG:
-			return Object.assign({}, state, { hostname: payload.hostname, loading: true });
-		case SET_CONFIG_ERROR:
+		case SET_HOSTNAME:
+			return Object.assign({}, state, { hostname: payload, loading: true });
+		case SET_HOSTNAME_ERROR:
 			return Object.assign({}, state, { loading: false, error: true });
-		case SET_CONFIG_SUCCESS:
+		case SET_HOSTNAME_SUCCESS:
 			return Object.assign({}, state, { redirect: true });
 		default:
 			return state;

--- a/plugins/lime-plugin-admin/src/adminSelectors.js
+++ b/plugins/lime-plugin-admin/src/adminSelectors.js
@@ -1,3 +1,4 @@
 export const loading = (state) => state.admin.loading;
 export const redirect = (state) => state.admin.redirect;
 export const error = (state) => state.admin.error;
+export const ipv4 = (state) => state.admin.ipv4;


### PR DESCRIPTION
Reduce node configuration to hostname selection.

This PR together with its corresponding PR at lime-packages -> lime-system repair the Node Configuration screen which was broken due to incompatible API. In order to keep the most common scenario only at LimeApp, the ability to change the ipv4 is also removed from this screen, and expected to be added back when we introduce support for guided setup of local services or other feature which requires setting up a custom ipv4.