### PR TITLE
fix(i18n): fix localization fallback

### DIFF
--- a/src/i18nline-glue.js
+++ b/src/i18nline-glue.js
@@ -1,6 +1,7 @@
 const extend = require('extend');
 const I18n = require('i18n-js');
-I18n.locale = navigator.language.split('-')[0];
+I18n.fallbacks = true;
+I18n.locale = navigator.language;
 require('i18nline/lib/extensions/i18n_js')(I18n);
 require('preact-i18nline/dist/extensions/i18n_js')(I18n);
 


### PR DESCRIPTION
Stop ignoring country specific translations by default. Ignore the country only as fallback mechanism
This fixes a non reported bug of brazilian portuguese translations (pt-br) not being shown at the LimeApp.
