### PR TITLE
fix(firmware): fix firmware upgrade when eupgrade is missing

### DIFF
--- a/plugins/lime-plugin-firmware/src/firmwareApi.js
+++ b/plugins/lime-plugin-firmware/src/firmwareApi.js
@@ -79,7 +79,13 @@ export function upgradeRevert() {
 }
 
 export function getNewVersion() {
-	return api.call("eupgrade", "is_new_version_available", {}).toPromise();
+	return api.call("eupgrade", "is_new_version_available", {}).toPromise()
+		.catch(error => {
+			if (error.code === -32000) {
+				return Promise.resolve(null)
+			}
+			throw error;
+		})
 }
 
 export function getDownloadStatus() {


### PR DESCRIPTION
Before this change, when eupgrade was not installed in the router and you try firmware upgrade from file, the file selection was ignored making it unusable.

Long version:
When eupgrade is not installed, ubus returns 32000 object not found, getNewVersion would throw and error and useNewVersion would be marked as an stalled query. When stalled queries are called, they refetch, and trigger rerendering of components using it In this case a child component (upgrade from file) would trigger rerender of parent component (upgrade page), leading to a loop which makes the component unusable.
