### PR TITLE
fix(remotesupport): fix remotesupport broken ui when no internet

### DIFF
--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
@@ -2,7 +2,7 @@ import api from 'utils/uhttpd.service';
 
 export function getSession() {
 	return api.call("tmate", "get_session", {}).toPromise()
-		.then(result => result.session !== 'no session' ? result.session : null)
+		.then(result => (result.session && result.session.rw_ssh) ? result.session : null)
 }
 
 export function openSession() {

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
@@ -7,6 +7,10 @@ export function getSession() {
 
 export function openSession() {
 	return api.call("tmate", "open_session", {}).toPromise()
+		.catch((error) => {
+			closeSession();
+			throw error;
+		})
 }
 
 export function closeSession() {

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
@@ -1,0 +1,102 @@
+import { of, throwError } from 'rxjs';
+import api from 'utils/uhttpd.service';
+import waitForExpect from 'wait-for-expect';
+
+jest.mock('utils/uhttpd.service')
+
+import { getSession, openSession, closeSession } from './remoteSupportApi';
+
+
+beforeEach(() => {
+    api.call.mockClear();
+})
+
+describe('getSession', () => {
+    it('calls the expected endpoint', async () => {
+        api.call.mockImplementation(() => of({ status: 'ok' }))
+        await getSession();
+        expect(api.call).toBeCalledWith('tmate', 'get_session', {});
+    })
+
+    it('resolves to session when there is a connected session', async () => {
+        const sessionData = {
+            rw_ssh: 'ssh -p2222 pL2qpxKQvPP9f9GPWjG2WkfrM@ny1.tmate.io',
+            ro_ssh: 'ssh -p2222 pL2qpxKQvPP9f9GPWjG2WkfrM@ny1.tmate.io'
+        };
+        api.call.mockImplementation(() => of(
+            {
+                status: 'ok',
+                session: sessionData,
+            }));
+        let session = await getSession();
+        expect(session).toEqual(sessionData);
+    });
+
+    it('resolves to null when there is no session', async () => {
+        const sessionData = 'no session';
+        api.call.mockImplementation(() => of(
+            {
+                status: 'ok',
+                session: sessionData,
+            }));
+        let session = await getSession();
+        expect(session).toBeNull();
+    });
+
+    it('resolves to null when there is a non established session', async () => {
+        const sessionData = {
+            rw_ssh: "", ro_ssh: ""
+        };
+        api.call.mockImplementation(() => of(
+            {
+                status: 'ok',
+                session: sessionData,
+            }));
+        let session = await getSession();
+        expect(session).toBeNull();
+    });
+});
+
+describe('closeSession', () => {
+    it('calls the expected endpoint', async () => {
+        api.call.mockImplementation(() => of({ status: 'ok' }))
+        await closeSession();
+        expect(api.call).toBeCalledWith('tmate', 'close_session', {})
+    })
+});
+
+describe('openSession', () => {
+    it('calls the expected endpoint', async () => {
+        api.call.mockImplementation(() => of({ status: 'ok' }))
+        await openSession();
+        expect(api.call).toBeCalledWith('tmate', 'open_session', {})
+    })
+
+    it('resolves to api response on success', async () => {
+        api.call.mockImplementation(() => of({ status: 'ok' }));
+        const result = await openSession();
+        expect(result).toEqual({ status: 'ok'})
+    })
+
+    it('rejects to api call error on error', async () => {
+        api.call.mockImplementationOnce(() => throwError('timeout'));
+        api.call.mockImplementationOnce(() => of({'status': 'ok'}));
+        expect.assertions(1);
+        try {
+            await openSession()
+        } catch (e) {
+            expect(e).toEqual('timeout')
+        }
+    })
+
+    it('calls close session when rejected ', async () => {
+        api.call.mockImplementationOnce(() => throwError('timeout'));
+        api.call.mockImplementationOnce(() => of({'status': 'ok'}));
+        expect.assertions(1);
+        try {
+            await openSession()
+        } catch (e) {
+            expect(api.call).toBeCalledWith('tmate', 'close_session', {})
+        }
+    })
+});

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportQueries.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportQueries.js
@@ -10,7 +10,7 @@ export function useSession(queryConfig) {
 export function useOpenSession() {
 	return useMutation(openSession, {
 		onSuccess: () => queryCache.invalidateQueries(["tmate", "get_session"]),
-		onError: () => closeSession().then(queryCache.setQueryData(["tmate", "get_session"], null))
+		onError: () => queryCache.setQueryData(["tmate", "get_session"], null)
 	})
 }
 

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportQueries.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportQueries.js
@@ -9,7 +9,8 @@ export function useSession(queryConfig) {
 
 export function useOpenSession() {
 	return useMutation(openSession, {
-		onSuccess: () => queryCache.invalidateQueries(["tmate", "get_session"])
+		onSuccess: () => queryCache.invalidateQueries(["tmate", "get_session"]),
+		onError: () => closeSession().then(queryCache.setQueryData(["tmate", "get_session"], null))
 	})
 }
 


### PR DESCRIPTION
Handle the case when the node has no connectivity with tmate server so it doesn't show  a broken UI in the LimeApp.

This could be handled in the backend: https://github.com/libremesh/lime-packages/issues/856
But as a workaround we can handle this at LimeApp.
