### PR TITLE
feat(help): add simple help component

### DIFF
--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -1,0 +1,27 @@
+import style from "./style.less";
+import { useToggle } from 'react-use';
+
+const Help = ({ Content }) => {
+    const [shown, toggleShown] = useToggle(false);
+    return (
+        <div>
+            <div class={style.symbol} onClick={toggleShown}>
+                ?
+            </div>
+            {shown && <div class={style.background}></div>}
+            {shown &&
+                <div class={style.tooltipWrapper} onClick={toggleShown}>
+                    <div class={`${style.tooltip} d-flex flex-column`}
+                        onClick={e => e.stopPropagation()}>
+                        <div class="d-flex flex-grow-1">
+                            <div class={style.tooltipX} onClick={toggleShown}>X</div>
+                        </div>
+                        <Content />
+                    </div>
+                </div>
+            }
+        </div>
+    )
+}
+
+export default Help;

--- a/src/components/help/index.js
+++ b/src/components/help/index.js
@@ -1,0 +1,2 @@
+export * from './help';
+export { default } from './help';

--- a/src/components/help/style.less
+++ b/src/components/help/style.less
@@ -1,0 +1,49 @@
+.symbol {
+	background: #F39100;
+	border-radius: 50%;
+	width: 2em;
+	z-index: 999;
+	color: white;
+	text-align: center;
+	line-height: 2em;
+    cursor: pointer;
+}
+
+.tooltip {
+    background: #fff;
+    border: 0.1em solid #F39100;
+    border-radius: 1em;
+    padding: 2em;
+    cursor:auto;
+}
+
+
+.tooltipWrapper {
+    z-index: 999;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3em;
+    cursor:pointer;
+}
+
+.tooltipX {
+    cursor:pointer;
+    margin-left: auto;
+}
+
+.background {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	height: 100%;
+	background: #fff;
+	z-index: 998;
+	width: 100%;
+	opacity: 70%;
+}


### PR DESCRIPTION
This new component let us add help texts on the LimeApp screens.

It opens the help message on click/tap.
This is how it looks:

<img src="https://user-images.githubusercontent.com/7140856/111205609-2d89c100-85a6-11eb-9588-5a529f289441.png" width="360px" />
<img src="https://user-images.githubusercontent.com/7140856/111205606-2bbffd80-85a6-11eb-8bb5-665f355448af.png" width="360px" />

In the future we may improve it to look like a real tooltip (with an arrow pointing to the help icon) and make it's size and position dynamic