### PR TITLE
Add dev tool: create skeleton of new plugin 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,15 @@ If you need more context to understand how to translate some key you can checkou
 And findout how is that key used in the LimeApp.
 Also, do not hesitate to contact developers directly :)
 
+### Creating a new plugin
+If you want to create a new plugin for the LimeApp you can use the developer tool `create-plugin` to bootstrap the files structure of a new
+plugin along with some minimal code to help you understand how each module relates to each other. Go ahead and run
+
+```
+npm install
+npm run create-plugin <yourPluginName (camelCased)>
+```
+
 ### More Information
 
 For more information, please see [Collaborating on projects using issues and pull requests](https://help.github.com/categories/collaborating-on-projects-using-issues-and-pull-requests/) in the GitHub help guide.

--- a/devTools/plugins.js
+++ b/devTools/plugins.js
@@ -1,0 +1,80 @@
+const path = require('path');
+const fs = require('fs');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const indexContent = (name, isCommunityProtected) =>
+    `import Page from './src/${name}Page';
+import Menu from './src/${name}Menu';
+
+export default {
+    name: '${name}',
+    page: Page,
+    menu: Menu,
+    isCommunityProtected: ${isCommunityProtected}
+};
+`
+
+const menuContent = (name, menuName) =>
+    `import { h } from 'preact';
+import I18n from 'i18n-js';
+
+const Menu = () => (
+	<a href={'#/${name.toLowerCase()}'}>{I18n.t('${menuName || name}')}</a>
+);
+
+export default Menu;
+`
+
+const pageContent = (name) => {
+    const componentName = name.charAt(0).toUpperCase() + name.slice(1);
+    return (
+        `import { h } from 'preact';
+
+const ${componentName} = () => {
+    return;
+}
+
+export default ${componentName};
+`)
+}
+
+const argv = yargs(hideBin(process.argv))
+    .command('$0 create <name>', 'create an skeleton for a new plugin',
+        yargs => yargs
+            .positional('name', {
+                describe: 'the name of your plugin without lime-plugin suffix',
+            })
+            .option('protected', {
+                alias: 'p', type: 'boolean', default: false,
+                describe: 'whether it is protected by shared password'
+            })
+            .option('menu-name', {
+                alias: 'm', type: 'string',
+                describe: 'name for the menu entry. Default to plugin name'
+            })
+        , create)
+    .help()
+    .argv
+
+
+
+function create(argv) {
+    const name = argv.name;
+    const pluginName = `lime-plugin-${name}`;
+    baseDir = path.join(__dirname, '..', 'plugins', pluginName);
+    fs.mkdirSync(baseDir);
+    fs.mkdirSync(path.join(baseDir, 'src'))
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Page.js`),
+        pageContent(name));
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Queries.js`), '');
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.js`), '');
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.spec.js`), '')
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Menu.js`),
+        menuContent(name, argv.menuName)
+    );
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Style.less`), '');
+    fs.writeFileSync(path.join(baseDir, 'index.js'),
+        indexContent(name, argv.protected));
+    fs.writeFileSync(path.join(baseDir, `${name}.spec.js`), '');
+}

--- a/devTools/plugins.js
+++ b/devTools/plugins.js
@@ -29,15 +29,108 @@ export default Menu;
 const pageContent = (name) => {
     const componentName = name.charAt(0).toUpperCase() + name.slice(1);
     return (
-        `import { h } from 'preact';
+        `// ${componentName} will be rendered when navigating to this plugin
+import { h } from 'preact';
+import style from './${name}Style.less';
+import { useSomething } from './${name}Queries';
 
 const ${componentName} = () => {
-    return;
+    const { data: something } = useSomething();
+    return (
+        <div>{ something }</div>
+    );
 }
 
 export default ${componentName};
 `)
 }
+
+const queriesContent = (name) =>
+    `// Here you define queries and mutations which connects the api with your components
+import { useQuery, useMutation } from 'react-query';
+import { getSomething } from './${name}Api';
+
+export const useSomething = () => useQuery(['package', 'command'], getSomething);
+`
+
+const apiContent = () =>
+    `// Here you define the api calls to the ubus uhttpd enpoints your plugin needs
+import api from 'utils/uhttpd.service';
+
+export const getSomething = () => api.call('package', 'command', {})
+`
+
+const apiSpecContent = (name) =>
+    `// Here you define unit tests for the api endpoints of this plugin
+import { getSomething } from './${name}Api'
+import api from 'utils/uhttpd.service';
+jest.mock('utils/uhttpd.service')
+
+beforeEach(() => {
+    api.call.mockImplementation(() => of({status: 'ok'}))
+})
+
+describe('getSomething', () => {
+    it('test some behaviour', async () => {
+        expect(true).toBeTrue();
+    });
+    it('test some other behaviour', async () => {
+        expect(true).toBeTrue();
+    });
+});
+`
+
+const specContent = (name) => {
+    const componentName = name.charAt(0).toUpperCase() + name.slice(1);
+    return (
+        `// Here you define tests that closely resemble how your component is used
+// Using the testing-library: https://testing-library.com
+
+import { h } from 'preact';
+import { screen, cleanup, act } from '@testing-library/preact';
+import '@testing-library/jest-dom';
+import { render } from 'utils/test_utils';
+import queryCache from 'utils/queryCache';
+
+import ${componentName} from './src/${name}Page';
+import { getSomething } from './src/${name}Api';
+
+jest.mock('./src/${name}Api');
+
+describe('${name}', () => {
+    beforeEach(() => {
+        getSomething.mockImplementation(async () => "something");
+    });
+
+    afterEach(() => {
+        cleanup();
+        act(() => queryCache.clear());
+    });
+
+    it('test that something is shown', async() => {
+        render(<${componentName} />);
+        expect(await screen.findByText('something')).toBeInTheDocument();
+    })
+});
+`)
+}
+
+const storiesContent = (name, menuName) => {
+    const componentName = name.charAt(0).toUpperCase() + name.slice(1);
+    return (
+        `//Here you define the StoryBook stories for this plugin
+
+import ${componentName} from './src/${name}Page';
+
+export default {
+    title: 'Containers/${menuName || name}'
+}
+
+export const myStory = () => <${componentName} />
+`);
+};
+
+const styleContent = () => "// Here you define the css for this plugin";
 
 const argv = yargs(hideBin(process.argv))
     .command('$0 create <name>', 'create an skeleton for a new plugin',
@@ -65,16 +158,15 @@ function create(argv) {
     baseDir = path.join(__dirname, '..', 'plugins', pluginName);
     fs.mkdirSync(baseDir);
     fs.mkdirSync(path.join(baseDir, 'src'))
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Page.js`),
-        pageContent(name));
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Queries.js`), '');
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.js`), '');
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.spec.js`), '')
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Menu.js`),
-        menuContent(name, argv.menuName)
-    );
-    fs.writeFileSync(path.join(baseDir, 'src', `${name}Style.less`), '');
-    fs.writeFileSync(path.join(baseDir, 'index.js'),
-        indexContent(name, argv.protected));
-    fs.writeFileSync(path.join(baseDir, `${name}.spec.js`), '');
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Page.js`), pageContent(name));
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Queries.js`), queriesContent(name));
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.js`), apiContent());
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Api.spec.js`), apiSpecContent(name));
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Menu.js`), menuContent(name, argv.menuName));
+    fs.writeFileSync(path.join(baseDir, 'src', `${name}Style.less`), styleContent());
+    fs.writeFileSync(path.join(baseDir, 'index.js'), indexContent(name, argv.protected));
+    fs.writeFileSync(path.join(baseDir, `${name}.spec.js`), specContent(name));
+    fs.writeFileSync(path.join(baseDir, `${name}.stories.js`), storiesContent(name));
+    const configPath = path.join(__dirname, '..', 'src', 'config.js');
+    console.log(`You are done. Remember to add ${name} to the list in ${configPath}`);
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "serve": "^11.1.0",
     "standard-version": "^8.0.1",
     "wait-for-expect": "^3.0.2",
-    "xhr-mock": "^2.5.1"
+    "xhr-mock": "^2.5.1",
+    "yargs": "^16.2.0"
   },
   "dependencies": {
     "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "storybook": "start-storybook",
     "storybook:build": "build-storybook -c .storybook",
     "storybook:deploy": "gh-pages -d storybook-static",
-    "test": "jest"
+    "test": "jest",
+    "create-plugin": "node ./devTools/plugins create"
   },
   "eslintConfig": {
     "extends": "eslint-config-synacor"


### PR DESCRIPTION
This PR introduce a developer tool: a script to create an skeleton for a new plugin.
The script is supposed to be run like this:
node devTools/plugin.js create myPlugin

And this will:
- Create the directory plugins/lime-plugin-myPlugin
- Create all the usual files needed for a new plugin Page, Api, Queries, Menu, Style, Tests and Stories and index.
- Some of these files include minimal examples of how things wire together. 
- It is very opinionated!

I hope this script will help both new comers and experienced devs to start a new plugin for the LimeApp without the boring initial boilerplate setup, and speed up development of further features.

Let me know your comments.