### PR TITLE
Simplify uhttpd service

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "if-env": "^1.0.0",
     "jest": "^24.9.0",
     "jest-extended": "^0.11.5",
+    "jest-fetch-mock": "^3.0.3",
     "jest-preset-preact": "^1.0.0",
     "jest-when": "^2.7.2",
     "per-env": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "yargs": "^16.2.0"
   },
   "dependencies": {
-    "axios": "^0.21.1",
     "history": "^4.7.2",
     "i18n-js": "^3.0.3",
     "jssha": "^2.3.1",

--- a/plugins/lime-plugin-align/src/alignApi.js
+++ b/plugins/lime-plugin-align/src/alignApi.js
@@ -1,9 +1,9 @@
 import api from 'utils/uhttpd.service';
 
 export const getMeshIfaces = () =>
-	api.call('lime-utils', 'get_mesh_ifaces', {}).toPromise()
+	api.call('lime-utils', 'get_mesh_ifaces', {})
 		.then(res => res.ifaces);
 
 export const getAssocList = (iface) =>
-	api.call('iwinfo', 'assoclist', {device: iface}).toPromise()
+	api.call('iwinfo', 'assoclist', {device: iface})
 		.then(res => res.results);

--- a/plugins/lime-plugin-fbw/src/api.js
+++ b/plugins/lime-plugin-fbw/src/api.js
@@ -1,4 +1,5 @@
 import api from 'utils/uhttpd.service';
+import { from } from 'rxjs';
 
 export const searchNetworks = (api, rescan) =>
 	api.call('lime-fbw', 'search_networks', { scan: rescan || false });
@@ -10,8 +11,8 @@ export const createNetwork = (api, { network, hostname, adminPassword }) =>
 	api.call('lime-fbw', 'create_network', { network, hostname, adminPassword });
 
 export const getFbwStatus = () =>
-	api.call('lime-fbw', 'status', {}).toPromise()
+	api.call('lime-fbw', 'status', {})
 		.catch(() => ({ lock: false }));
 
 export const dismissFbw = () =>
-	api.call('lime-fbw', 'dismiss', {}).toPromise();
+	api.call('lime-fbw', 'dismiss', {});

--- a/plugins/lime-plugin-firmware/src/firmwareApi.js
+++ b/plugins/lime-plugin-firmware/src/firmwareApi.js
@@ -7,18 +7,11 @@ import path from 'path';
 import api from 'utils/uhttpd.service';
 
 export function getUpgradeInfo() {
-	return api.call('lime-utils', 'get_upgrade_info', {}).toPromise()
-		.then(response => new Promise((res, rej) => {
-			if (response.status === 'ok') {
-				res({
-					...response,
-					suCounter: Number(response.safe_upgrade_confirm_remaining_s)
-				});
-			}
-			else {
-				rej(response.message);
-			}
-		}));
+	return api.call('lime-utils', 'get_upgrade_info', {})
+		.then(response => ({
+			...response,
+			suCounter: Number(response.safe_upgrade_confirm_remaining_s)
+		}))
 }
 
 export function uploadFile(file) {
@@ -30,11 +23,11 @@ export function uploadFile(file) {
 		formData.append("sessionid", api.sid());
 		formData.append("filename", destPath);
 		formData.append("filedata", file)
-	
+
 		request.addEventListener('loadend', () => {
 			res(destPath);
 		});
-	
+
 		request.addEventListener('error', (error) => {
 			rej(error)
 		});
@@ -50,36 +43,18 @@ export function upgradeFirmware(filepath) {
 			fw_path: filepath,
 			metadata: { upgrade_timestamp: (Date.now() / 1000).toFixed(1) } // in seconds;
 		})
-		.toPromise()
-		.then(response => new Promise((res, rej) => {
-			if (response.status === 'ok') {
-				res(true);
-			}
-			else {
-				rej(response.message);
-			}
-		}));
 }
 
 export function upgradeConfirm() {
-	return api.call('lime-utils-admin', 'firmware_confirm', {})
-		.toPromise()
-		.then(response => new Promise((res, rej) => {
-			if (response.status === 'ok') {
-				res(true);
-			}
-			else {
-				rej(false);
-			}
-		}))
+	return api.call('lime-utils-admin', 'firmware_confirm', {});
 }
 
 export function upgradeRevert() {
-	return api.call('system', 'reboot', {}).toPromise().then(() => true);
+	return api.call('system', 'reboot', {}).then(() => true);
 }
 
 export function getNewVersion() {
-	return api.call("eupgrade", "is_new_version_available", {}).toPromise()
+	return api.call("eupgrade", "is_new_version_available", {})
 		.catch(error => {
 			if (error.code === -32000) {
 				return Promise.resolve(null)
@@ -89,9 +64,9 @@ export function getNewVersion() {
 }
 
 export function getDownloadStatus() {
-	return api.call("eupgrade", "download_status", {}).toPromise();
+	return api.call("eupgrade", "download_status", {});
 }
 
 export function downloadRelease() {
-	return api.call('eupgrade', 'start_download', {}).toPromise();
+	return api.call('eupgrade', 'start_download', {});
 }

--- a/plugins/lime-plugin-network-admin/src/netAdminPage.js
+++ b/plugins/lime-plugin-network-admin/src/netAdminPage.js
@@ -79,7 +79,6 @@ const NetAdminHOC = () => {
 		setSubmitting(true);
 		return api
 			.call('lime-utils-admin', 'set_root_password', { password })
-			.toPromise()
 			.then(result => new Promise((res, rej) => {
 				result.status === 'ok' ? res() : rej();
 			}))

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.js
@@ -1,12 +1,12 @@
 import api from 'utils/uhttpd.service';
 
 export function getSession() {
-	return api.call("tmate", "get_session", {}).toPromise()
+	return api.call("tmate", "get_session", {})
 		.then(result => (result.session && result.session.rw_ssh) ? result.session : null)
 }
 
 export function openSession() {
-	return api.call("tmate", "open_session", {}).toPromise()
+	return api.call("tmate", "open_session", {})
 		.catch((error) => {
 			closeSession();
 			throw error;
@@ -14,5 +14,5 @@ export function openSession() {
 }
 
 export function closeSession() {
-	return api.call("tmate", "close_session", {}).toPromise()
+	return api.call("tmate", "close_session", {})
 }

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
@@ -1,6 +1,4 @@
-import { of, throwError } from 'rxjs';
 import api from 'utils/uhttpd.service';
-import waitForExpect from 'wait-for-expect';
 
 jest.mock('utils/uhttpd.service')
 
@@ -9,11 +7,11 @@ import { getSession, openSession, closeSession } from './remoteSupportApi';
 
 beforeEach(() => {
     api.call.mockClear();
+    api.call.mockImplementation(async () => ({ status: 'ok' }));
 })
 
 describe('getSession', () => {
     it('calls the expected endpoint', async () => {
-        api.call.mockImplementation(() => of({ status: 'ok' }))
         await getSession();
         expect(api.call).toBeCalledWith('tmate', 'get_session', {});
     })
@@ -23,7 +21,7 @@ describe('getSession', () => {
             rw_ssh: 'ssh -p2222 pL2qpxKQvPP9f9GPWjG2WkfrM@ny1.tmate.io',
             ro_ssh: 'ssh -p2222 pL2qpxKQvPP9f9GPWjG2WkfrM@ny1.tmate.io'
         };
-        api.call.mockImplementation(() => of(
+        api.call.mockImplementation(async () => (
             {
                 status: 'ok',
                 session: sessionData,
@@ -34,7 +32,7 @@ describe('getSession', () => {
 
     it('resolves to null when there is no session', async () => {
         const sessionData = 'no session';
-        api.call.mockImplementation(() => of(
+        api.call.mockImplementation(async () => (
             {
                 status: 'ok',
                 session: sessionData,
@@ -47,7 +45,7 @@ describe('getSession', () => {
         const sessionData = {
             rw_ssh: "", ro_ssh: ""
         };
-        api.call.mockImplementation(() => of(
+        api.call.mockImplementation(async () => (
             {
                 status: 'ok',
                 session: sessionData,
@@ -59,7 +57,6 @@ describe('getSession', () => {
 
 describe('closeSession', () => {
     it('calls the expected endpoint', async () => {
-        api.call.mockImplementation(() => of({ status: 'ok' }))
         await closeSession();
         expect(api.call).toBeCalledWith('tmate', 'close_session', {})
     })
@@ -67,20 +64,18 @@ describe('closeSession', () => {
 
 describe('openSession', () => {
     it('calls the expected endpoint', async () => {
-        api.call.mockImplementation(() => of({ status: 'ok' }))
         await openSession();
         expect(api.call).toBeCalledWith('tmate', 'open_session', {})
     })
 
     it('resolves to api response on success', async () => {
-        api.call.mockImplementation(() => of({ status: 'ok' }));
         const result = await openSession();
         expect(result).toEqual({ status: 'ok'})
     })
 
     it('rejects to api call error on error', async () => {
-        api.call.mockImplementationOnce(() => throwError('timeout'));
-        api.call.mockImplementationOnce(() => of({'status': 'ok'}));
+        api.call.mockImplementationOnce(() => Promise.reject('timeout'));
+        api.call.mockImplementationOnce(async () => ({'status': 'ok'}));
         expect.assertions(1);
         try {
             await openSession()
@@ -90,8 +85,8 @@ describe('openSession', () => {
     })
 
     it('calls close session when rejected ', async () => {
-        api.call.mockImplementationOnce(() => throwError('timeout'));
-        api.call.mockImplementationOnce(() => of({'status': 'ok'}));
+        api.call.mockImplementationOnce(() => Promise.reject('timeout'));
+        api.call.mockImplementationOnce(async () => ({'status': 'ok'}));
         expect.assertions(1);
         try {
             await openSession()

--- a/src/store/createStore.js
+++ b/src/store/createStore.js
@@ -4,6 +4,11 @@ import { routerMiddleware } from 'react-router-redux';
 
 import { history } from './history';
 import uhttpdService from '../utils/uhttpd.service';
+import { from } from 'rxjs';
+
+const api = {
+	call: (...params) => from(uhttpdService.call(...params))
+};
 
 export default (initialState,rootEpics,rootReducers) => {
 
@@ -12,7 +17,7 @@ export default (initialState,rootEpics,rootReducers) => {
 	const reduxRouterMiddleware = routerMiddleware(history);
 
 	const epicMiddleware = createEpicMiddleware({
-		dependencies: { wsAPI: uhttpdService }
+		dependencies: { wsAPI: api }
 	});
 
 	const enhancer = composeEnhancers(

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,7 @@
 import api from 'utils/uhttpd.service';
 
 export function getBatHost(mac, outgoingIface) {
-	return api.call('bat-hosts', 'get_bathost', {mac, outgoing_iface: outgoingIface}).toPromise()
+	return api.call('bat-hosts', 'get_bathost', {mac, outgoing_iface: outgoingIface})
 		.then(response => new Promise((res, rej) => {
 			if (response.status === 'ok') {
 				res(response.bathost);

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -6,7 +6,6 @@ import queryCache from './queryCache';
 
 function getSession() {
 	return api.call('session', 'get', {ubus_rpc_session: api.sid()})
-		.toPromise()
 		.then(res => res.values);
 }
 
@@ -32,7 +31,7 @@ export function useLogin() {
 }
 
 function getBoardData() {
-	return api.call('system', 'board', {}).toPromise();
+	return api.call('system', 'board', {});
 }
 
 export function useBoardData() {
@@ -52,7 +51,7 @@ const DEFAULT_COMMUNITY_SETTINGS = {
 
 
 function getCommunitySettings() {
-	return api.call('lime-utils', 'get_community_settings', {}).toPromise()
+	return api.call('lime-utils', 'get_community_settings', {})
 		.then(res => ({...res, DEFAULT_COMMUNITY_SETTINGS }))
 		.catch(() => DEFAULT_COMMUNITY_SETTINGS);
 }

--- a/src/utils/uhttpd.service.js
+++ b/src/utils/uhttpd.service.js
@@ -1,26 +1,19 @@
-import axios from 'axios';
-import { from } from 'rxjs';
-
-String.prototype.hashCode = function() {
-	let hash = 0;
-	if (this.length === 0) {
-		return hash;
-	}
-	for (let i = 0; i < this.length; i++) {
-		let char = this.charCodeAt(i);
-		hash = ((hash<<5)-hash)+char;
-		hash = hash & hash;
-	}
-	return hash.toString();
-};
-
-const getHash = (json ) => Promise.resolve(json.hashCode());
-
 const UNAUTH_SESSION_ID = '00000000000000000000000000000000';
 const DEFAULT_SESSION_TIMEOUT = 5000;
 
+const parseResult = result =>
+	new Promise((res, rej) => {
+		if (result.error) { return rej(result.error); }
+		if (result.result[0] !== 0) { return rej(result); }
+		result = result.result[1];
+		if (result.status === 'error') {
+			return rej(result.message);
+		}
+		return res(result);
+	})
+
 export class UhttpdService {
-	constructor(){
+	constructor() {
 		this.url = window.origin + '/ubus';
 		this.jsonrpc = '2.0';
 		this.sec = 0;
@@ -31,72 +24,30 @@ export class UhttpdService {
 		return sessionStorage.getItem('sid');
 	}
 
-	addId(){
+	addId() {
 		this.sec += 1;
 		return Number(this.sec);
 	}
-	
-	pullRequest(){
-		if (this.requestList.length > 0) {
-			this.requestList[0].callRequest();
-		}
-	}
 
-	runCallbacks(result, callbacks) {
-		callbacks.map(({ res, rej }) => {
-			if (result.error) { return rej(result.error);}
-			if (result.result[0] !== 0) { return rej(result);}
-			res(result.result[1]);
-		});
-	}
 
-	request(payload, customSid=null) {
-		return new Promise((res, rej) => {
-			const sid = customSid || this.sid();
-			getHash(JSON.stringify([sid, ...payload])).then(hash => {
-				if (this.requestList.filter(x => x.hash === hash).length > 0) {
-					this.requestList.filter(x => x.hash === hash)[0].callbacks = [...this.requestList.filter(x => x.hash === hash)[0].callbacks, { res,rej }];
-					return;
-				}
-				const id = this.addId();
-				this.requestList = [...this.requestList, {
-					hash,
-					id,
-					callbacks: [{ res,rej }],
-					callRequest: () => axios.post(this.url, {
-						id,
-						jsonrpc: this.jsonrpc,
-						method: 'call',
-						params: [sid, ...payload]
-					}, { timeout: 15000 })
-						.then(x => {
-							const callbacks = this.requestList.filter(x => x.id === id)[0].callbacks;
-							this.runCallbacks(x.data, callbacks);
-							this.requestList = this.requestList.filter(x => x.id !== id);
-							this.pullRequest();
-							
-						})
-						.catch(e => {
-							rej(e);
-							this.requestList = this.requestList.filter(x => x.id !== id);
-							this.pullRequest();
-						})
-				}];
-				if (this.requestList.length === 1) {
-					this.requestList[0].callRequest();
-				}
-			});
-		});
-	}
-	
-
-	call(action, method, data, customSid=null) {
-		return from(this.request([action, method, data], customSid));
+	call(action, method, data, customSid = null) {
+		const body = {
+			id: addId(),
+			jsonrpc: this.jsonrpc,
+			method: 'call',
+			params: [customSid || this.sid(), action, method, data]
+		};
+		const controller = new AbortController();
+		const id = setTimeout(() => controller.abort(), 15000);
+		return fetch(this.url,
+			{ method: 'POST', body, signal: controller.signal })
+			.then(parseResult)
+			.finally(clearTimeout(id));
 	}
 
 	login(username, password) {
 		const data = { username, password, timeout: DEFAULT_SESSION_TIMEOUT };
-		return this.request(['session', 'login', data], UNAUTH_SESSION_ID)
+		return this.call('session', 'login', data, UNAUTH_SESSION_ID)
 			.then(response =>
 				new Promise((res, rej) => {
 					if (response.ubus_rpc_session) {

--- a/src/utils/uhttpd.service.js
+++ b/src/utils/uhttpd.service.js
@@ -31,8 +31,9 @@ export class UhttpdService {
 
 
 	call(action, method, data, customSid = null) {
+		this.sec +=1;
 		const body = {
-			id: addId(),
+			id: this.addId(),
 			jsonrpc: this.jsonrpc,
 			method: 'call',
 			params: [customSid || this.sid(), action, method, data]
@@ -40,7 +41,8 @@ export class UhttpdService {
 		const controller = new AbortController();
 		const id = setTimeout(() => controller.abort(), 15000);
 		return fetch(this.url,
-			{ method: 'POST', body, signal: controller.signal })
+			{ method: 'POST', body: JSON.stringify(body), signal: controller.signal })
+			.then(response => response.json())
 			.then(parseResult)
 			.finally(clearTimeout(id));
 	}

--- a/src/utils/uhttpd.service.spec.js
+++ b/src/utils/uhttpd.service.spec.js
@@ -1,0 +1,59 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+enableFetchMocks()
+
+import api from 'utils/uhttpd.service';
+
+describe('uhttpd.service', () => {
+    beforeEach(() => {
+        fetch.resetMocks();
+    });
+
+    it('resolves to response on successfull response', async () => {
+        const result = {
+            "safe_upgrade_confirm_remaining_s": -1,
+            "status": "ok",
+            "is_upgrade_confirm_supported": false
+        };
+        fetch.mockResponse(JSON.stringify({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "result": [0, result]
+        }));
+        expect(await api.call('lime-utils', 'get_upgrade_info', {}))
+            .toEqual(result);
+    });
+
+    it('rejects on ubus response with result code distinct from 0', async () => {
+        fetch.mockResponse(JSON.stringify({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "result": [3]
+        }));
+        return expect(api.call('lime-utils', 'get_upgrade_info', {}))
+            .toReject();
+    });
+
+    it('rejects on ubus response with error object', async () => {
+        fetch.mockResponse(JSON.stringify({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "error": { code:-32002, message:"Access denied"}
+        }));
+        return expect(api.call('lime-utils-admin', 'firmware_upgrade', {'fw_path': '/tmp/firmware'}))
+            .toReject();
+    });
+
+    it('rejects to message on ubus response with status error', async () => {
+        fetch.mockResponse(JSON.stringify({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "result": [0, { status: "error", message:"Invalid Firmware"}]
+        }));
+        expect.assertions(1);
+        try {
+            await api.call('lime-utils-admin', 'firmware_upgrade', {'fw_path': '/tmp/firmware'});
+        } catch (e) {
+            expect(e).toEqual('Invalid Firmware');
+        }
+    });
+});


### PR DESCRIPTION
This PR simplifies the logic of uhttpd.service.

Before the service implemented a queue for requests, so they were
issued by the client one a time.
This queue need isn't documented, but I was told it was due to uhttpd
server not being able to receive many requests concurrently.
A lot of water has pass down the bridge. I had test removing this queue
in my local setup, and didn't find any issue. My proposal is to keep
an eye on it during the development of the next release.

Also, `axios` was used in order to support request timeout, that can be
achieved today with [AbortController API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
which is supported in main browsers since 2017-2018.
It was replaced by fetch + AbortController. Reducing the final bundle size by 16KB.


The returned value by api.call was an Observable (from rx-js).
We are migrating all plugins out from rx-js.
Following this trend, api.call now returns a Promise, this simplifies
the code for all the plugins expecting a Promise to work with.
A modification in the api instance used at the Redux Store was done to
keep compatibility to those plugins that still uses the store.