### PR TITLE
fixed(getVoices): used an if to check compability with speechsyntesis

### DIFF
--- a/plugins/lime-plugin-align/src/speech.js
+++ b/plugins/lime-plugin-align/src/speech.js
@@ -1,11 +1,13 @@
-let synth = window.speechSynthesis;
-let voices = synth.getVoices();
+const synth = window.speechSynthesis;
 
 export const speech = (text, lang) => {
-	let utterThis = new SpeechSynthesisUtterance(text);
-	utterThis.pitch = 0.9;
-	utterThis.rate = 1.2;
-	utterThis.voice = voices.filter(x => x.lang === lang)[0];
-	synth.cancel();
-	synth.speak(utterThis);
+	if(synth != "undefined") {
+		let voices = synth.getVoices();
+		let utterThis = new SpeechSynthesisUtterance(text);
+		utterThis.pitch = 0.9;
+		utterThis.rate = 1.2;
+		utterThis.voice = voices.filter(x => x.lang === lang)[0];
+		synth.cancel();
+		synth.speak(utterThis);
+	}
 };

--- a/plugins/lime-plugin-align/src/speech.js
+++ b/plugins/lime-plugin-align/src/speech.js
@@ -1,7 +1,7 @@
 const synth = window.speechSynthesis;
 
 export const speech = (text, lang) => {
-	if(synth != "undefined") {
+	if(synth !== undefined) {
 		let voices = synth.getVoices();
 		let utterThis = new SpeechSynthesisUtterance(text);
 		utterThis.pitch = 0.9;


### PR DESCRIPTION
This PR adds a fix that checks if the navigator has compatibility with speechsyntesis before use it.

Without checking it, on some navigators (like WebView) the page doesn't load, showing a white screen without any information. As we're building a network capability app for the LibreMesh routers, we tried it on the app, and got these logs:

![imagen](https://user-images.githubusercontent.com/42981462/125210091-e1a90900-e273-11eb-981b-bbd1af10c2d2.png)

The fix consists of checking if the object is defined, and proceed or not.