### PR TITLE
Fix eslint issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
-test/*.conf.js
-build/
+node_modules
+coverage
+storybook-static
+build
+package-lock.json
+i18n

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "plugins": ["testing-library", "jest"],
   "extends": [
-    "eslint-config-synacor",
+    // "eslint-config-synacor",
     "plugin:react-hooks/recommended",
     "plugin:testing-library/react",
     "plugin:jest/recommended",

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Massive linting commits:
+5c335c0846c88fbf39c0f34b1ae5c5bbf03b637c

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/devTools/plugins.js
+++ b/devTools/plugins.js
@@ -133,7 +133,7 @@ export const myStory = () => <${componentName} />
 
 const styleContent = () => "// Here you define the css for this plugin";
 
-const argv = yargs(hideBin(process.argv))
+yargs(hideBin(process.argv))
     .command('$0 create <name>', 'create an skeleton for a new plugin',
         yargs => yargs
             .positional('name', {
@@ -156,7 +156,7 @@ const argv = yargs(hideBin(process.argv))
 function create(argv) {
     const name = argv.name;
     const pluginName = `lime-plugin-${name}`;
-    baseDir = path.join(__dirname, '..', 'plugins', pluginName);
+    const baseDir = path.join(__dirname, '..', 'plugins', pluginName);
     fs.mkdirSync(baseDir);
     fs.mkdirSync(path.join(baseDir, 'src'))
     fs.writeFileSync(path.join(baseDir, 'src', `${name}Page.js`), pageContent(name));

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 		'<rootDir>/plugins/**/__tests__/**/*.{mjs,js,jsx,ts,tsx}',
 		'<rootDir>/{plugins, src,test,tests}/**/*.{spec,test}.{mjs,js,jsx,ts,tsx}'
 	],
+	setupFiles: ['core-js'],
 	setupFilesAfterEnv: ['jest-extended'],
 	moduleNameMapper: {
 		...preactPreset.moduleNameMapper,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "storybook:build": "build-storybook -c .storybook",
     "storybook:deploy": "gh-pages -d storybook-static",
     "test": "jest",
-    "create-plugin": "node ./devTools/plugins create"
+    "create-plugin": "node ./devTools/plugins create",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
@@ -52,7 +53,7 @@
     "eslint-plugin-testing-library": "^3.1.4",
     "fetch-mock": "^8.3.2",
     "gh-pages": "^2.0.1",
-    "husky": "^3.0.0",
+    "husky": "^7.0.0",
     "identity-obj-proxy": "^3.0.0",
     "if-env": "^1.0.0",
     "jest": "^24.9.0",
@@ -62,6 +63,7 @@
     "jest-when": "^2.7.2",
     "less": "^3.12.2",
     "less-loader": "^6.2.0",
+    "lint-staged": "^12.3.4",
     "per-env": "^1.0.2",
     "serve": "^11.1.0",
     "standard-version": "^8.0.1",
@@ -97,5 +99,8 @@
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS"
     }
+  },
+  "lint-staged": {
+    "*.js": "eslint --fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,6 @@
     "test": "jest",
     "create-plugin": "node ./devTools/plugins create"
   },
-  "eslintConfig": {
-    "extends": "eslint-config-synacor"
-  },
-  "eslintIgnore": [
-    "build/*"
-  ],
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",

--- a/plugins/lime-plugin-firmware/index.js
+++ b/plugins/lime-plugin-firmware/index.js
@@ -1,12 +1,11 @@
-import {h} from 'preact';
-import { Trans } from '@lingui/macro';
 import FirmwarePage from './src/firmwarePage';
+import { Menu } from './src/firmwareMenu';
 import { UpgradeAvailabeInfo } from './src/upgradeAvailable';
 
 export default {
 	name: 'Firmware',
 	page: FirmwarePage,
-	menu: () => <a href={'#/firmware'}><Trans>Firmware</Trans></a>,
+	menu: Menu,
 	isCommunityProtected: true,
 	additionalRoutes: [
 		['releaseInfo', UpgradeAvailabeInfo]

--- a/plugins/lime-plugin-firmware/src/firmwareMenu.js
+++ b/plugins/lime-plugin-firmware/src/firmwareMenu.js
@@ -1,0 +1,3 @@
+import {h} from 'preact';
+import { Trans } from '@lingui/macro';
+export const Menu = () => <a href={'#/firmware'}><Trans>Firmware</Trans></a>;

--- a/plugins/lime-plugin-firmware/src/upgradeAvailable.js
+++ b/plugins/lime-plugin-firmware/src/upgradeAvailable.js
@@ -1,8 +1,7 @@
-import { h } from "preact";
+import { h, Fragment } from "preact";
 import { route } from 'preact-router';
 import Match from 'preact-router/match';
 import { Trans } from '@lingui/macro';
-import { Fragment } from 'preact';
 import { useNewVersion } from './firmwareQueries';
 import Loading from 'components/loading';
 import { useBoardData } from 'utils/queries';

--- a/plugins/lime-plugin-ground-routing/src/groundRoutingPage.js
+++ b/plugins/lime-plugin-ground-routing/src/groundRoutingPage.js
@@ -14,7 +14,7 @@ const Page = ({ getGroundRouting, loading, configuration }) => {
 	
 	useEffect(() => {
 		getGroundRouting();
-	}, []);
+	}, [getGroundRouting]);
 
 	const preStyle = {
 		backgroundColor: '#f5f5f5',

--- a/plugins/lime-plugin-ground-routing/src/groundRoutingReducer.js
+++ b/plugins/lime-plugin-ground-routing/src/groundRoutingReducer.js
@@ -12,7 +12,7 @@ export const initialState = {
 	error: false
 };
 
-export const reducer = (state = initialState, { type, payload, meta }) => {
+export const reducer = (state = initialState, { type, payload }) => {
 	switch (type) {
 
 		case GROUNDROUTING_GET:

--- a/plugins/lime-plugin-locate/locate.stories.js
+++ b/plugins/lime-plugin-locate/locate.stories.js
@@ -1,6 +1,6 @@
 import { LocatePage } from './src/locatePage';
 import { action } from '@storybook/addon-actions';
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 
 export default {
 	title: 'Containers/Map',
@@ -12,8 +12,6 @@ const actions = {
 	loadLocation: action('loadLocation'),
 	loadLocationLinks: action('loadLocationLinks')
 }
-
-const nodeHostname = text('nodeHostname', 'ql-anaymarcos');
 
 export const nodeAndCommunityNotLocated = () => (
 	<LocatePage

--- a/plugins/lime-plugin-locate/src/assetsUtils.js
+++ b/plugins/lime-plugin-locate/src/assetsUtils.js
@@ -11,7 +11,7 @@ function loadLeafletScript() {
             document.body.appendChild(script);
         }
     })
-};
+}
 
 function loadLeafletStylesheet() {
     return new Promise((res, rej) => {
@@ -27,7 +27,7 @@ function loadLeafletStylesheet() {
             document.head.appendChild(style);
         }
     })
-};
+}
 
 
 export function loadLeafLet() {
@@ -44,7 +44,7 @@ export function loadGoogleMapsApi() {
             const script = document.createElement('script');
             script.onload = res;
             script.onerror = rej;
-            script.src = 'https://maps.googleapis.com/maps/api/js?key='+key;
+            script.src = `https://maps.googleapis.com/maps/api/js?key=${key}`;
             script.id = 'googlemaps-script';
             document.body.appendChild(script);
         }

--- a/plugins/lime-plugin-locate/src/communityGeoJSON.js
+++ b/plugins/lime-plugin-locate/src/communityGeoJSON.js
@@ -67,7 +67,7 @@ export function getCommunityGeoJSON(nodesData, keepClean = null) {
             .filter(mac => node.macs.some(node_mac => macLinks[mac].indexOf(node_mac) != -1))
             .map(mac => [geomac[node.macs[0]], geomac[mac]].sort())
     ).flat()
-    geolinks = removeDuplicates(geolinks, l => l[0] + ',' + l[1]);
+    geolinks = removeDuplicates(geolinks, l => `${l[0]},${l[1]}`);
 
     // nodefeatures: [..., GeoJSONFeature:Point] All nodes to be shown
     let nodefeatures = nodes.map(node => coordsToPoint(

--- a/plugins/lime-plugin-locate/src/communityGeoJSON.spec.js
+++ b/plugins/lime-plugin-locate/src/communityGeoJSON.spec.js
@@ -1,66 +1,66 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "compareGeoJsons"] }] */
 import { getCommunityGeoJSON } from './communityGeoJSON'
-
 const getMockedNodesData = jest.fn(() => (
     {
-        "host1": {
-            "bleachTTL": 29,
-            "data": {
-                "hostname": "host1",
-                "coordinates": {
-                    "lon": "-64.42818",
-                    "lat": "-31.81317"
+        host1: {
+            bleachTTL: 29,
+            data: {
+                hostname: "host1",
+                coordinates: {
+                    lon: "-64.42818",
+                    lat: "-31.81317"
                 },
-                "macs": [
+                macs: [
                     "a0:f3:c1:86:31:d2",
                     "a0:f3:c1:86:31:d3",
                     "a2:f3:c1:86:31:d2"
                 ],
-                "links": [
+                links: [
                     "a0:f3:c1:46:28:37",
                     "a8:40:41:1c:85:44"
                 ]
             },
-            "author": "host1"
+            author: "host1"
         },
-        "host2": {
-            "bleachTTL": 30,
-            "data": {
-                "links": [
+        host2: {
+            bleachTTL: 30,
+            data: {
+                links: [
                     "a0:f3:c1:86:31:d2",
                     // Link to host3, but host3 doenst link host2
                     "a8:40:41:1c:84:20"
                 ],
-                "coordinates": {
-                    "lon": "-64.42450",
-                    "lat": "-31.81799"
+                coordinates: {
+                    lon: "-64.42450",
+                    lat: "-31.81799"
                 },
-                "macs": [
+                macs: [
                     "a0:f3:c1:46:28:36",
                     "a0:f3:c1:46:28:37",
                     "a2:f3:c1:46:28:36"
                 ],
-                "hostname": "host2"
+                hostname: "host2"
             },
-            "author": "host2"
+            author: "host2"
         },
-        "host3": {
-            "bleachTTL": 30,
-            "data": {
-                "hostname": "host3",
-                "coordinates": {
-                    "lon": "-64.39950",
-                    "lat": "-31.79970"
+        host3: {
+            bleachTTL: 30,
+            data: {
+                hostname: "host3",
+                coordinates: {
+                    lon: "-64.39950",
+                    lat: "-31.79970"
                 },
-                "macs": [
+                macs: [
                     "a8:40:41:1c:84:20",
                     "a8:40:41:1c:84:28",
                     "a8:40:41:1c:85:44"
                 ],
-                "links": [
+                links: [
                     "a0:f3:c1:86:31:d3",
                 ]
             },
-            "author": "host3"
+            author: "host3"
         }
     }
 ));
@@ -78,14 +78,14 @@ test('getCommunityGeoJSON returns a well formed geo JSON', () => {
     const nodesData = getMockedNodesData();
     const geoJSON = getCommunityGeoJSON(nodesData);
     const expected = {
-        "type": "FeatureCollection",
-        "features": [
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.42818,-31.81317]},"properties":{"name":"host1"}},
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.42450,-31.81799]},"properties":{"name":"host2"}},
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.39950,-31.79970]},"properties":{"name":"host3"}},
+        type: "FeatureCollection",
+        features: [
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.42818, -31.81317] }, properties: { name: "host1" } },
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.42450, -31.81799] }, properties: { name: "host2" } },
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.39950, -31.79970] }, properties: { name: "host3" } },
             // Note: coordinates list is expected to be sorted to simplify testing
-            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[-64.42818,-31.81317],[-64.42450,-31.81799]].sort()}},
-            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[-64.42818,-31.81317],[-64.39950,-31.79970]].sort()}}
+            { type: "Feature", geometry: { type: "LineString", coordinates: [[-64.42818, -31.81317], [-64.42450, -31.81799]].sort() } },
+            { type: "Feature", geometry: { type: "LineString", coordinates: [[-64.42818, -31.81317], [-64.39950, -31.79970]].sort() } }
         ]
 
     };
@@ -94,15 +94,15 @@ test('getCommunityGeoJSON returns a well formed geo JSON', () => {
 
 test('getCommunityGeoJSON ignore nodes without coordinates and their links', () => {
     let nodesData = getMockedNodesData();
-    nodesData.host2.data.coordinates = {lat: 'FIXME', lon: 'FIXME'};
+    nodesData.host2.data.coordinates = { lat: 'FIXME', lon: 'FIXME' };
     const geoJSON = getCommunityGeoJSON(nodesData);
     const expected = {
-        "type": "FeatureCollection",
-        "features": [
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.42818,-31.81317]},"properties":{"name":"host1"}},
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.39950,-31.79970]},"properties":{"name":"host3"}},
+        type: "FeatureCollection",
+        features: [
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.42818, -31.81317] }, properties: { name: "host1" } },
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.39950, -31.79970] }, properties: { name: "host3" } },
             // Note: coordinates list is expected to be sorted to simplify testing
-            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[-64.42818,-31.81317],[-64.39950,-31.79970]].sort()}}
+            { type: "Feature", geometry: { type: "LineString", coordinates: [[-64.42818, -31.81317], [-64.39950, -31.79970]].sort() } }
         ]
     };
     compareGeoJsons(geoJSON, expected);
@@ -113,12 +113,12 @@ test('getCommunityGeoJSON ignore nodes without mac addresses', () => {
     nodesData.host2.data.macs = [];
     const geoJSON = getCommunityGeoJSON(nodesData);
     const expected = {
-        "type": "FeatureCollection",
-        "features": [
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.42818,-31.81317]},"properties":{"name":"host1"}},
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.39950,-31.79970]},"properties":{"name":"host3"}},
+        type: "FeatureCollection",
+        features: [
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.42818, -31.81317] }, properties: { name: "host1" } },
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.39950, -31.79970] }, properties: { name: "host3" } },
             // Note: coordinates list is expected to be sorted to simplify testing
-            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[-64.42818,-31.81317],[-64.39950,-31.79970]].sort()}}
+            { type: "Feature", geometry: { type: "LineString", coordinates: [[-64.42818, -31.81317], [-64.39950, -31.79970]].sort() } }
         ]
     };
     compareGeoJsons(geoJSON, expected);
@@ -127,13 +127,13 @@ test('getCommunityGeoJSON ignore nodes without mac addresses', () => {
 test('getCommunityGeoJSON doesnt return geo points in keepClean coordinates', () => {
     let nodesData = getMockedNodesData();
     nodesData.host2.data.macs = [];
-    const geoJSON = getCommunityGeoJSON(nodesData, [-64.42818,-31.81317]);
+    const geoJSON = getCommunityGeoJSON(nodesData, [-64.42818, -31.81317]);
     const expected = {
-        "type": "FeatureCollection",
-        "features": [
-            {"type":"Feature","geometry":{"type":"Point","coordinates":[-64.39950,-31.79970]},"properties":{"name":"host3"}},
+        type: "FeatureCollection",
+        features: [
+            { type: "Feature", geometry: { type: "Point", coordinates: [-64.39950, -31.79970] }, properties: { name: "host3" } },
             // Note: coordinates list is expected to be sorted to simplify testing
-            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[-64.42818,-31.81317],[-64.39950,-31.79970]].sort()}}
+            { type: "Feature", geometry: { type: "LineString", coordinates: [[-64.42818, -31.81317], [-64.39950, -31.79970]].sort() } }
         ]
     };
     compareGeoJsons(geoJSON, expected);

--- a/plugins/lime-plugin-locate/src/locateEpics.js
+++ b/plugins/lime-plugin-locate/src/locateEpics.js
@@ -26,7 +26,7 @@ const locateChange = ( action$, _state$, { wsAPI } ) =>
 	action$.pipe(
 		ofType(LOCATION_CHANGE),
 		mergeMap((action) => changeLocation(wsAPI, action.payload)),
-		map((payload) => ({ type: LOCATION_CHANGE_SUCCESS }))
+		map(() => ({ type: LOCATION_CHANGE_SUCCESS }))
 	);
 
 const locateLoadlinks = ( action$, _state$, { wsAPI } ) =>

--- a/plugins/lime-plugin-locate/src/locatePage.js
+++ b/plugins/lime-plugin-locate/src/locatePage.js
@@ -75,10 +75,20 @@ export const LocatePage = ({ editting, submitting, stationLat, stationLon, nodes
 			.catch(onAssetsError)
 			.then(loadLocation) // Load node location
 			.then(loadLocationLinks); // Load community locations
-	}, []);
+	}, [loadLocation, loadLocationLinks]);
 
 	// Set map position when map is available or location gets updated
 	useEffect(() => {
+		function updateNodeMarker(lat, lon) {
+			if (nodeMarker) {
+				nodeMarker.setLatLng([lat, lon]);
+			}
+			else {
+				const marker = L.marker([lat, lon], { icon: L.icon(homeIcon), alt: 'node marker' }).addTo(map);
+				setNodeMarker(marker);
+			}
+		}
+
 		if (map && stationLat) {
 			map.setView([stationLat, stationLon], 13);
 			updateNodeMarker(stationLat, stationLon);
@@ -86,7 +96,7 @@ export const LocatePage = ({ editting, submitting, stationLat, stationLon, nodes
 		else if (map) {
 			map.setView([-30, -60], 3);
 		}
-	}, [stationLat, stationLon, map]);
+	}, [stationLat, stationLon, map, nodeMarker]);
 
 	// Center the map on the node also when editting is turned on
 	useEffect(() => {
@@ -118,16 +128,6 @@ export const LocatePage = ({ editting, submitting, stationLat, stationLon, nodes
 		if (communityLayer) {
 			// Hide the community view, to avoid outdated links
 			toogleCommunityLayer();
-		}
-	}
-
-	function updateNodeMarker(lat, lon) {
-		if (nodeMarker) {
-			nodeMarker.setLatLng([lat, lon]);
-		}
-		else {
-			const marker = L.marker([lat, lon], { icon: L.icon(homeIcon), alt: 'node marker' }).addTo(map);
-			setNodeMarker(marker);
 		}
 	}
 

--- a/plugins/lime-plugin-metrics/src/components/box/index.js
+++ b/plugins/lime-plugin-metrics/src/components/box/index.js
@@ -43,14 +43,14 @@ const style = {
 const Box = ({ station, settings, loading, click, gateway }) => {
 	function barStyle(loss) {
 		return Object.assign({},style.line,{
-			width: ((station.bandwidth*100/settings.good_bandwidth) || 3).toString()+'%',
+			width: `${((station.bandwidth*100/settings.good_bandwidth) || 3).toString()}%`,
 			maxWidth: '100%',
 			backgroundColor: colorScale.getColor(loss)
 		});
 	}
 
 	function isGateway(gateway, hostname){
-		return (gateway === true)? hostname + ' (Gateway)' : hostname;
+		return (gateway === true)? `${hostname  } (Gateway)` : hostname;
 	}
 
 	function onClick() {

--- a/plugins/lime-plugin-metrics/src/metricsEpics.js
+++ b/plugins/lime-plugin-metrics/src/metricsEpics.js
@@ -32,7 +32,7 @@ const loadGateway = ( action$, _store, { wsAPI }) =>
 const loadPath = ( action$, store, { wsAPI }) =>
 	action$.pipe(
 		ofType(LOAD_GATEWAY_SUCCESS),
-		mergeMap((action) => getPath(wsAPI, { target: store.value.metrics.gateway })),
+		mergeMap(() => getPath(wsAPI, { target: store.value.metrics.gateway })),
 		mergeMap(payload => {
 			if (!payload.error) return [{ type: LOAD_PATH_SUCCESS, payload: payload.path }, { type: LOAD_METRICS_GATEWAY }];
 			return [{ type: LOAD_PATH_NOT_FOUND, payload }];
@@ -43,7 +43,7 @@ const loadPath = ( action$, store, { wsAPI }) =>
 const loadLastPath = ( action$, _store, { wsAPI }) =>
 	action$.pipe(
 		ofType(LOAD_GATEWAY_NOT_FOUND),
-		mergeMap((action) => getLastKnownPath(wsAPI, {})),
+		mergeMap(() => getLastKnownPath(wsAPI, {})),
 		mergeMap(payload => {
 			if (!payload.error) return [{ type: LOAD_PATH_SUCCESS, payload: payload.path }, { type: LOAD_METRICS_ALL }];
 			return [{ type: LOAD_PATH_NOT_FOUND, payload }];
@@ -54,7 +54,7 @@ const loadLastPath = ( action$, _store, { wsAPI }) =>
 const loadMetrics = ( action$, store, { wsAPI }) =>
 	action$.pipe(
 		ofType(LOAD_METRICS_ALL),
-		map(action => store.value.metrics.metrics), // Get array of paths
+		map(() => store.value.metrics.metrics), // Get array of paths
 		map(paths => from(paths).pipe(
 			concatMap((path) => getMetrics(wsAPI, { target: path.host.ip })) // Change array of paths for array of observables
 		)),
@@ -66,7 +66,7 @@ const loadGatewayMetrics = ( action$, store, { wsAPI }) =>
 	action$.pipe(
 		ofType(LOAD_METRICS_GATEWAY),
 		map(action => action.payload),
-		mergeMap(payload => {
+		mergeMap( () => {
 			if (store.value.metrics.gateway !== store.value.metrics.nodeHostname) {
 				return getMetrics(wsAPI, { target: store.value.metrics.gateway }).pipe(
 					map(payload => ({ type: LOAD_METRICS_GATEWAY_SUCCESS, payload })));

--- a/plugins/lime-plugin-metrics/src/metricsPage.js
+++ b/plugins/lime-plugin-metrics/src/metricsPage.js
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
-
+import { i18n } from '@lingui/core';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
@@ -144,7 +144,7 @@ useEffect(() => {
 		inputEnd: 30
 	});
 	return () => { };
-}, [boardData]);
+}, [boardData, getMetricsGateway, getInternetStatus]);
 
 return (
 	<div class="container container-padded" style={{ textAlign: 'center' }}>

--- a/plugins/lime-plugin-node-admin/src/layouts/configPageLayout.spec.js
+++ b/plugins/lime-plugin-node-admin/src/layouts/configPageLayout.spec.js
@@ -1,9 +1,8 @@
 
 import { h } from 'preact';
 
-import { screen, fireEvent, cleanup, act } from '@testing-library/preact';
+import { screen, fireEvent } from '@testing-library/preact';
 import '@testing-library/jest-dom';
-import waitForExpect from 'wait-for-expect';
 
 import { render } from 'utils/test_utils';
 import { route } from 'preact-router';
@@ -16,7 +15,7 @@ const findBackArrow = async () =>
 describe('config layout', () => {
     it('renders the title for the config', async() => {
         render(<ConfigPageLayout title={"My Config"} />);
-        expect(await screen.findByText('My Config'));
+        expect(await screen.findByText('My Config')).toBeInTheDocument();
     });
 
     it('routes back to node admin when clicking on back arrow', async() => {

--- a/plugins/lime-plugin-node-admin/src/nodeAdminApi.js
+++ b/plugins/lime-plugin-node-admin/src/nodeAdminApi.js
@@ -6,7 +6,7 @@ export const changeHostname = (hostname) =>
 
 export const changeApNamePassword = ({password, enablePassword}) =>
     api.call('wireless-service-admin', 'set_node_ap',
-        { password: password, "has_password": enablePassword });
+        { password, has_password: enablePassword });
 
 export const getAPsData = () =>
     api.call('wireless-service', 'get_access_points_data', {});

--- a/plugins/lime-plugin-node-admin/src/screens/hostname.js
+++ b/plugins/lime-plugin-node-admin/src/screens/hostname.js
@@ -15,11 +15,11 @@ const HostnamePage = () => {
 
     useEffect(() => {
         reset({ hostname: boardData && boardData.hostname });
-    }, [boardData]);
+    }, [boardData, reset]);
 
     function onSubmit({ hostname }) {
         changeHostname(hostname);
-    };
+    }
 
     return (
         <ConfigPageLayout {...{

--- a/plugins/lime-plugin-node-admin/src/screens/hotspot/src/components/testBoxes.js
+++ b/plugins/lime-plugin-node-admin/src/screens/hotspot/src/components/testBoxes.js
@@ -22,7 +22,7 @@ const TestBox = ({
             <div class="d-flex flex-grow-1 ">
                 {isFetching ?
                     <div class="flex-grow-1 justify-content-center">
-                        <Loading color={bgClass !== 'bg-gray' ? 'white' : null}/>
+                        <Loading color={bgClass !== 'bg-gray' ? 'white' : null} />
                     </div>
                     :
                     <div class="d-flex flex-grow-1">{children}</div>

--- a/plugins/lime-plugin-node-admin/src/screens/hotspot/src/components/testBoxes.spec.js
+++ b/plugins/lime-plugin-node-admin/src/screens/hotspot/src/components/testBoxes.spec.js
@@ -12,10 +12,18 @@ jest.mock('../hotspotApi');
 jest.mock('utils/api');
 
 describe('ConnectionToThePhone TestBox', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
     beforeEach(() => {
         getStatus.mockImplementation(async () => ({ enabled: true, connected: false }));
     });
-    
+
     afterEach(() => {
         getStatus.mockClear();
         cleanup();
@@ -31,9 +39,9 @@ describe('ConnectionToThePhone TestBox', () => {
         render(<ConnectionToThePhone />);
         expect(await screen.findByText('Connection to the cellphone')).toBeInTheDocument();
     });
-    
+
     it('shows connected and signal when the node is connected to the cellphone', async () => {
-        getStatus.mockImplementation(async () => ({ enabled:true, connected: true, signal: -47 }));
+        getStatus.mockImplementation(async () => ({ enabled: true, connected: true, signal: -47 }));
         render(<ConnectionToThePhone />);
         expect(await screen.findByText('Connected')).toBeInTheDocument();
         expect(await screen.findByText('-47')).toBeInTheDocument();
@@ -47,16 +55,15 @@ describe('ConnectionToThePhone TestBox', () => {
 
     it('shows loading while fetching', async () => {
         render(<ConnectionToThePhone />);
-        expect(await screen.getByLabelText('loading')).toBeInTheDocument();
+        expect(screen.getByLabelText('loading')).toBeInTheDocument();
     });
 
     it('refreshes on click', async () => {
         render(<ConnectionToThePhone />);
         expect(await screen.findByText('Not Connected')).toBeInTheDocument();
-        getStatus.mockImplementation(async() => ({ enabled: true, connected: true}));
+        getStatus.mockImplementation(async () => ({ enabled: true, connected: true }));
         const elem = screen.getByTestId('hotspot-phone-test');
         fireEvent.click(elem);
-        expect(await screen.findByLabelText('loading')).toBeInTheDocument();
         expect(await screen.findByText('Connected')).toBeInTheDocument();
     });
 });
@@ -66,7 +73,7 @@ describe('ConnectionToTheInternet TestBox', () => {
     beforeEach(() => {
         checkInternet.mockImplementation(async () => ({ connected: false }));
     });
-    
+
     afterEach(() => {
         checkInternet.mockClear();
         cleanup();
@@ -82,7 +89,7 @@ describe('ConnectionToTheInternet TestBox', () => {
         render(<ConnectionToTheInternet />);
         expect(await screen.findByText('Connection to the internet')).toBeInTheDocument();
     });
-    
+
     it('shows connected when the node is connected to the cellphone', async () => {
         checkInternet.mockImplementation(async () => ({ connected: true }));
         render(<ConnectionToTheInternet />);
@@ -96,16 +103,15 @@ describe('ConnectionToTheInternet TestBox', () => {
 
     it('shows loading while fetching', async () => {
         render(<ConnectionToTheInternet />);
-        expect(await screen.getByLabelText('loading')).toBeInTheDocument();
+        expect(screen.getByLabelText('loading')).toBeInTheDocument();
     });
 
     it('refreshes on click', async () => {
         render(<ConnectionToTheInternet />);
         expect(await screen.findByText('Not Connected')).toBeInTheDocument();
-        checkInternet.mockImplementation(async() => ({connected: true}));
+        checkInternet.mockImplementation(async () => ({ connected: true }));
         const elem = screen.getByTestId('hotspot-internet-test');
         fireEvent.click(elem);
-        expect(await screen.findByLabelText('loading')).toBeInTheDocument();
         expect(await screen.findByText('Connected')).toBeInTheDocument();
     });
 });

--- a/plugins/lime-plugin-node-admin/src/screens/hotspot/src/hotspotPage.js
+++ b/plugins/lime-plugin-node-admin/src/screens/hotspot/src/hotspotPage.js
@@ -136,11 +136,11 @@ const HotspotPage = () => {
                 refetch();
             }, 10000);
         }
-    }, [waitingRadioReset])
+    }, [waitingRadioReset, refetch])
 
     function onSubmit({ enabled }) {
         return toggle(enabled);
-    };
+    }
 
     return (
         <ConfigPageLayout {...{

--- a/plugins/lime-plugin-node-admin/src/screens/hotspot/src/hotspotQueries.js
+++ b/plugins/lime-plugin-node-admin/src/screens/hotspot/src/hotspotQueries.js
@@ -16,5 +16,5 @@ export const useToggleHotspot = () =>
     useMutation(toggle, {
         onSuccess: (enabled) => queryCache.setQueryData(
             ['lime-utils', 'hotspot_wwan_get_status'],
-            { enabled: enabled, waitingForRadioReset: true })
+            { enabled, waitingForRadioReset: true })
     });

--- a/plugins/lime-plugin-node-admin/src/screens/password.js
+++ b/plugins/lime-plugin-node-admin/src/screens/password.js
@@ -68,7 +68,7 @@ const APPasswordPage = () => {
             password: enablePassword ? password: "",
             enablePassword
         });
-    };
+    }
 
     return (
         <ConfigPageLayout {...{

--- a/plugins/lime-plugin-node-admin/src/screens/roamingAP.js
+++ b/plugins/lime-plugin-node-admin/src/screens/roamingAP.js
@@ -46,7 +46,7 @@ const RoamingAPPage = () => {
 
     function onSubmit({ enableRoamingAP }) {
         return setupRoamingAP({ enabled: enableRoamingAP });
-    };
+    }
 
     return (
         <ConfigPageLayout {...{

--- a/plugins/lime-plugin-notes/src/notesPage.js
+++ b/plugins/lime-plugin-notes/src/notesPage.js
@@ -28,7 +28,7 @@ export const Page = ({ setNotes, getNotes, notes, loading }) => {
 	useEffect(() => {
 		getNotes();
 		return () => {};
-	}, []);
+	}, [getNotes]);
 
 	//After notes reload
 	useEffect(() => {

--- a/plugins/lime-plugin-pirania/index.js
+++ b/plugins/lime-plugin-pirania/index.js
@@ -1,6 +1,5 @@
-import {h} from 'preact';
-import { Trans } from '@lingui/macro';
 import PiraniaPage from './src/piraniaPage';
+import PiraniaMenu from './src/piraniaMenu';
 import { WellcomeScreenEditor } from './src/screens/wellcomeScreenEditor';
 import CreateVoucher from "./src/screens/createVoucher";
 import EditVoucher from "./src/screens/editVoucher";
@@ -10,7 +9,7 @@ import Voucher from "./src/screens/voucher";
 export default {
 	name: 'Access',
 	page: PiraniaPage,
-	menu: () => <a href={'#/access'}><Trans>Access Vouchers</Trans></a>,
+	menu: PiraniaMenu,
 	isCommunityProtected: true,
 	additionalProtectedRoutes: [
 		['access/wellcomescreen', WellcomeScreenEditor],

--- a/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigItem.spec.js
+++ b/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigItem.spec.js
@@ -13,8 +13,8 @@ jest.mock('../src/piraniaApi');
 describe('portal config item', () => {
     beforeEach(() => {
         getPortalConfig.mockImplementation(async () => ({
-            'activated': true,
-            'with_vouchers': true, 
+            activated: true,
+            with_vouchers: true, 
         }));
     });
 
@@ -35,8 +35,8 @@ describe('portal config item', () => {
 
     it('shows value as Enabled, without vouchers', async() => {
         getPortalConfig.mockImplementation(async () => ({
-            'activated': true,
-            'with_vouchers': false, 
+            activated: true,
+            with_vouchers: false, 
         }));
         render(<PortalConfigItem />);
         expect(await screen.findByText('Enabled, without vouchers')).toBeVisible();
@@ -44,8 +44,8 @@ describe('portal config item', () => {
 
     it('shows value as Disabled', async() => {
         getPortalConfig.mockImplementation(async () => ({
-            'activated': false,
-            'with_vouchers': false, 
+            activated: false,
+            with_vouchers: false, 
         }));
         render(<PortalConfigItem />);
         expect(await screen.findByText('Disabled')).toBeVisible();

--- a/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigPage.spec.js
+++ b/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigPage.spec.js
@@ -89,7 +89,7 @@ describe('portal config page', () => {
         fireEvent.click(button);
         await waitForExpect(() => {
             expect(setPortalConfig).toBeCalledWith({
-                'activated': true, 'with_vouchers': true
+                activated: true, with_vouchers: true
             });
         });
         fireEvent.click(await findActiveCheckbox());
@@ -97,14 +97,14 @@ describe('portal config page', () => {
         fireEvent.click(button);
         await waitForExpect(() => {
             expect(setPortalConfig).toBeCalledWith({
-                'activated': false, 'with_vouchers': false
+                activated: false, with_vouchers: false
             });
         });
         fireEvent.click(await findActiveCheckbox());
         fireEvent.click(button);
         await waitForExpect(() => {
             expect(setPortalConfig).toBeCalledWith({
-                'activated': true, 'with_vouchers': false
+                activated: true, with_vouchers: false
             });
         });
         fireEvent.click(await findActiveCheckbox());
@@ -112,7 +112,7 @@ describe('portal config page', () => {
         fireEvent.click(button);
         await waitForExpect(() => {
             expect(setPortalConfig).toBeCalledWith({
-                'activated': false, 'with_vouchers': true
+                activated: false, with_vouchers: true
             });
         });
     });

--- a/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigPage.stories.js
+++ b/plugins/lime-plugin-pirania/nodeAdmin/PortalConfigPage.stories.js
@@ -4,7 +4,7 @@ export default {
     title: 'Containers/Node Configuration/Portal Config'
 }
 
-export const activeWithoutVouchers = () => < PortalConfigPage/>;
+export const activeWithoutVouchers = () => <PortalConfigPage />;
 activeWithoutVouchers.args = {
     queries: [
         [['pirania', 'get_portal_config'], {
@@ -13,7 +13,7 @@ activeWithoutVouchers.args = {
     ]
 };
 
-export const activeWithVouchers = () => < PortalConfigPage/>;
+export const activeWithVouchers = () => <PortalConfigPage />;
 activeWithVouchers.args = {
     queries: [
         [['pirania', 'get_portal_config'], {

--- a/plugins/lime-plugin-pirania/src/components/copy.js
+++ b/plugins/lime-plugin-pirania/src/components/copy.js
@@ -27,11 +27,11 @@ const Copy = ({ text, className }) => {
 			return await navigator.clipboard.writeText(
 				ref.current.innerText
 			);
-		} else {
+		} 
 			// clipboard API works only on https sites
 			selectText(ref.current.firstChild);
 			return document.execCommand("copy");
-		}
+		
 	}
 
 	const handleCopyClick = (e) => {

--- a/plugins/lime-plugin-pirania/src/components/voucherListItem.js
+++ b/plugins/lime-plugin-pirania/src/components/voucherListItem.js
@@ -20,16 +20,16 @@ const VoucherListItem = ({
 		route(`/access/view/${id}`);
 	}
 	const statusMsgs = {
-		'available': <Trans>Available</Trans>,
-		'expired': <Trans>Expired</Trans>,
-		'active': <Trans>Active</Trans>,
-		'invalidated': <Trans>Invalidated</Trans>
+		available: <Trans>Available</Trans>,
+		expired: <Trans>Expired</Trans>,
+		active: <Trans>Active</Trans>,
+		invalidated: <Trans>Invalidated</Trans>
 	};
 
 	const statusClassName = {
-		'available': style.voucherStatusAvailable,
-		'active': 'text-primary',
-		'expired': 'text-danger'
+		available: style.voucherStatusAvailable,
+		active: 'text-primary',
+		expired: 'text-danger'
 	};
 
 	return (

--- a/plugins/lime-plugin-pirania/src/components/voucherListItem.spec.js
+++ b/plugins/lime-plugin-pirania/src/components/voucherListItem.spec.js
@@ -46,11 +46,13 @@ describe("voucher list item", () => {
 		['Invalidated', 'invalidated'],
 
 	]).it("shows the voucher status as %s when status is %s", async (expected, status) => {
-		const voucher_ = { ...voucher, status: status };
+		const voucher_ = { ...voucher, status };
 		render(<VoucherListItem {...voucher_} />);
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect(await screen.findByText(expected)).toBeInTheDocument();
 	});
 
+	
 	it("shows vouchers creation date", async () => {
 		render(<VoucherListItem {...voucher} />);
 		const timeAgo = timeago.format(new Date(voucher.creation_date * 1000));

--- a/plugins/lime-plugin-pirania/src/piraniaApi.js
+++ b/plugins/lime-plugin-pirania/src/piraniaApi.js
@@ -29,7 +29,6 @@ export const createCompression = (file) =>
         });
     });
 export function listVouchers() {
-	const now = new Date().getTime() / 1000;
 	return api.call("pirania", "list_vouchers", {})
 		.then(response =>response.vouchers)
 		.catch((error) => {

--- a/plugins/lime-plugin-pirania/src/piraniaMenu.js
+++ b/plugins/lime-plugin-pirania/src/piraniaMenu.js
@@ -1,0 +1,7 @@
+import { h } from "preact";
+import { Trans } from '@lingui/macro';
+
+const PiraniaMenu = () =>
+    <a href={'#/access'}><Trans>Access Vouchers</Trans></a>
+
+export default PiraniaMenu;

--- a/plugins/lime-plugin-pirania/src/screens/createVoucher.js
+++ b/plugins/lime-plugin-pirania/src/screens/createVoucher.js
@@ -21,10 +21,10 @@ const CreateVoucher = () => {
 
 		const finalData = {
 			...formData,
-			qty: parseInt(formData.qty),
+			qty: parseInt(formData.qty, 10),
 			duration_m: (
 				formData.permanent ?
-					null : parseInt(formData.duration_m) * 24 * 60
+					null : parseInt(formData.duration_m, 10) * 24 * 60
 			),
 			activation_deadline: deadline
 		};
@@ -36,7 +36,7 @@ const CreateVoucher = () => {
 
 	if (createdVouchers) {
 		return <PostCreate vouchers={createdVouchers} />
-	};
+	}
 
 	return (
 		<ConfigPageLayout {...{

--- a/plugins/lime-plugin-pirania/src/screens/editVoucher.js
+++ b/plugins/lime-plugin-pirania/src/screens/editVoucher.js
@@ -49,7 +49,7 @@ const EditVoucher = ({ id }) => {
 	const submitVoucher = async ({ name }) => {
 		return renameVoucher({
 			id: voucher.id,
-			name: name
+			name
 		});
 	};
 

--- a/plugins/lime-plugin-pirania/src/screens/postCreate.js
+++ b/plugins/lime-plugin-pirania/src/screens/postCreate.js
@@ -21,7 +21,7 @@ const Duration = ({ days }) => {
 const PostCreate = ({ vouchers }) => {
 	const { name, duration_m,
 		activation_deadline } = vouchers[0];
-	const durationInDays = duration_m && parseInt(duration_m / (24 * 60));
+	const durationInDays = duration_m && parseInt(duration_m / (24 * 60), 10);
 	const deadlineText = activation_deadline && (
 		i18n.date(activation_deadline * 1000,
 			{ dateStyle: "medium", timeStyle: "medium" })

--- a/plugins/lime-plugin-pirania/src/screens/postCreate.spec.js
+++ b/plugins/lime-plugin-pirania/src/screens/postCreate.spec.js
@@ -48,7 +48,7 @@ describe("voucher post create screen", () => {
 
 	it('shows duration in days if not permanent', async () => {
 		render(<PostCreate vouchers={vouchers} />);
-		const durationDays = parseInt(vouchers[0].duration_m / (24 * 60))
+		const durationDays = parseInt(vouchers[0].duration_m / (24 * 60), 10)
 		expect(await screen.findByText(
 			`Duration: ${durationDays} days`)
 		).toBeInTheDocument();

--- a/plugins/lime-plugin-pirania/src/screens/voucher.js
+++ b/plugins/lime-plugin-pirania/src/screens/voucher.js
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { Trans } from '@lingui/macro';
+import { Trans, Plural } from '@lingui/macro';
 import { route } from "preact-router";
 import style from "../style.less";
 import { useListVouchers } from "../piraniaQueries";
@@ -8,10 +8,10 @@ import Copy from "../components/copy";
 import { i18n } from "@lingui/core";
 
 const statusMsgs = {
-	'available': <Trans>Available</Trans>,
-	'expired': <Trans>Expired</Trans>,
-	'active': <Trans>Active</Trans>,
-	'invalidated': <Trans>Invalidated</Trans>
+	available: <Trans>Available</Trans>,
+	expired: <Trans>Expired</Trans>,
+	active: <Trans>Active</Trans>,
+	invalidated: <Trans>Invalidated</Trans>
 };
 
 const formatDate = (date) => Number.isInteger(date) && i18n.date(new Date(date * 1000),
@@ -33,7 +33,7 @@ const VoucherDetails = ({
 	permanent,
 	author_node,
 }) => {
-	const durationInDays = duration_m && parseInt(duration_m / (24 * 60));
+	const durationInDays = duration_m && parseInt(duration_m / (24 * 60), 10);
 	return (
 		<div class="d-flex flex-grow-1 flex-column container-padded">
 			<div class="d-flex flex-grow-1 flex-column">

--- a/plugins/lime-plugin-pirania/src/screens/voucher.spec.js
+++ b/plugins/lime-plugin-pirania/src/screens/voucher.spec.js
@@ -77,6 +77,7 @@ describe("Voucher details", () => {
 		};
 		listVouchers.mockImplementation(async () => [voucher_]);
 		render(<Voucher id={voucher_.id} />);
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect(await screen.findByText(
 			`Status: ${expected}`)
 		).toBeInTheDocument();
@@ -109,7 +110,7 @@ describe("Voucher details", () => {
 
 	it('shows duration in days if not permanent', async () => {
 		render(<Voucher id={voucher.id} />);
-		const durationDays = parseInt(voucher.duration_m / (24 * 60))
+		const durationDays = parseInt(voucher.duration_m / (24 * 60), 10)
 		expect(await screen.findByText(
 			`Duration: ${durationDays} days`)
 		).toBeInTheDocument();
@@ -143,9 +144,11 @@ describe("Voucher details", () => {
 		]);
 		render(<Voucher id={voucher.id} />);
 		const button = await screen.findByRole("button", { name: /invalidate/i });
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect(button).toBeInTheDocument();
 		fireEvent.click(button);
 		await waitForExpect(() => {
+			// eslint-disable-next-line jest/no-standalone-expect
 			expect(route).toHaveBeenCalledWith(`/access/invalidate/${voucher.id}`);
 		});
 	});
@@ -161,7 +164,9 @@ describe("Voucher details", () => {
 		]);
 		render(<Voucher id={voucher.id} />);
 		// wait for something to be rendered.
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect(await screen.findByText(voucher.code)).toBeInTheDocument();
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect(
 			screen.queryByRole("button", { name: /invalidate/i })
 		).toBeNull();

--- a/plugins/lime-plugin-pirania/src/screens/voucher.stories.js
+++ b/plugins/lime-plugin-pirania/src/screens/voucher.stories.js
@@ -14,7 +14,6 @@ const voucher = {
     creation_date: 1631880790,
     status: 'active',
     author_node: 'ql-berta',
-    activation_date: 1631881790,
 }
 
 export const voucherDetails = () => (

--- a/plugins/lime-plugin-pirania/src/screens/voucherList.js
+++ b/plugins/lime-plugin-pirania/src/screens/voucherList.js
@@ -18,7 +18,7 @@ const VoucherList = () => {
 
 	const filteredVoucher = vouchers
 		.sort((a, b) => {
-			return parseInt(a.creation_date) < parseInt(b.creation_date) ? 1 : -1
+			return parseInt(a.creation_date, 10) < parseInt(b.creation_date, 10) ? 1 : -1
 		})
 		.filter((voucher) => {
 			if (filterSelection === "all-vouchers") return true;

--- a/plugins/lime-plugin-pirania/src/screens/voucherList.spec.js
+++ b/plugins/lime-plugin-pirania/src/screens/voucherList.spec.js
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "selectFilterOption", "findExpectedVouchers"] }] */
 import { h } from "preact";
 import { fireEvent, screen, act, cleanup } from "@testing-library/preact";
 import { render } from "utils/test_utils";
@@ -110,7 +111,7 @@ const selectFilterOption = async (option) => {
 	userEvent.selectOptions(select,
 		screen.getByRole('option', { name: option })
 	);
-	expect(screen.getByRole('option', { name: option }));
+	expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
 };
 
 const findExpectedVouchers = async (expectedVouchers) => {

--- a/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.js
+++ b/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.js
@@ -26,14 +26,14 @@ const WellcomeScreenEditorForm = (
                 <span><RequiredMsg /> (<MaxLengthMsg length={100} />)</span>
                 <input type="text" name="title" id="title" class="w-100"
                     ref={register({ required: true, maxLength: 100 })}
-                ></input>
+                 />
                 {errors.title?.type === 'required' && <RequiredErrorMsg />}
                 {errors.title?.type === 'maxLength' && <MaxLengthErrorMsg length={100} />}
                 <label for="main_text"><Trans>Main Text</Trans></label>
                 <span><RequiredMsg /> (<MaxLengthMsg length={500} />)</span>
                 <textarea name="main_text" id="main_text" class="w-100" style={{ minHeight: '9em' }}
                     ref={register({ required: true, maxLength: 500 })}
-                ></textarea>
+                 />
                 {errors.main_text?.type === 'required' && <RequiredErrorMsg />}
                 {errors.main_text?.type === 'maxLength' && <MaxLengthErrorMsg length={500} />}
                 <label for="logo_file"><Trans>Community Logo</Trans></label>
@@ -53,7 +53,7 @@ const WellcomeScreenEditorForm = (
                 <label for="background_color"><Trans>Background Color</Trans></label>
                 <input type="color" name="background_color" id="background_color"
                     ref={register({ required: true })}
-                ></input>
+                 />
                 {errors.background_color?.type === 'required' && <RequiredErrorMsg />}
                 <h4><Trans>Local services link</Trans></h4>
                 <p><Trans>If your community network has local services, you can point a link to them.</Trans></p>
@@ -61,13 +61,13 @@ const WellcomeScreenEditorForm = (
                 <span><MaxLengthMsg length={100} /></span>
                 <input type="text" name="link_title" id="link_title" class="w-100"
                     ref={register({ maxLength: 100 })}
-                ></input>
+                 />
                 {errors.link_title?.type === 'maxLength' && <MaxLengthErrorMsg length={100} />}
                 <label for="link_url"><Trans>Link URL</Trans></label>
                 <span><Trans>It must start with https:// or http://</Trans></span>
                 <input type="text" name="link_url" id="link_url" class="w-100"
                     ref={register({ pattern: /^(http:\/\/|https:\/\/).*$/ })}
-                ></input>
+                 />
                 {errors.link_url?.type === 'pattern' &&
                     <p style={{ color: "#923838" }}><Trans>It must start with https:// or http://</Trans></p>
                 }

--- a/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.spec.js
+++ b/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.spec.js
@@ -206,6 +206,6 @@ describe('portal wellcome screen', () => {
         await fillLinkData('mysite.com');
         const submitButton = await findSubmitButton();
         fireEvent.click(submitButton);
-        expect(await screen.findByText('It must start with https:// or http://'));
+        expect(await screen.findByText('It must start with https:// or http://')).toBeInTheDocument();
     });
 });

--- a/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.stories.js
+++ b/plugins/lime-plugin-pirania/src/screens/wellcomeScreenEditor.stories.js
@@ -4,7 +4,7 @@ export default {
     title: 'Containers/WellcomeScreenEditor'
 }
 
-export const wellcomeScreenWithoutLogo = () => < WellcomeScreenEditor />;
+export const wellcomeScreenWithoutLogo = () => <WellcomeScreenEditor />;
 wellcomeScreenWithoutLogo.args = {
     queries: [
         [['pirania', 'get_portal_page_content'],
@@ -18,7 +18,7 @@ wellcomeScreenWithoutLogo.args = {
     ]
 };
 
-export const wellcomeScreenWithLogo = () => < WellcomeScreenEditor />;
+export const wellcomeScreenWithLogo = () => <WellcomeScreenEditor />;
 wellcomeScreenWithLogo.args = {
     queries: [
         [['pirania', 'get_portal_page_content'],

--- a/plugins/lime-plugin-remotesupport/index.js
+++ b/plugins/lime-plugin-remotesupport/index.js
@@ -1,12 +1,11 @@
-import {h} from 'preact';
-import { Trans } from '@lingui/macro';
 import RemoteSupportPage from './src/remoteSupportPage';
+import Menu from './src/remoteSupportMenu';
 import ConsoleView from './src/consoleView';
 
 export default {
 	name: 'remotesupport',
 	page: RemoteSupportPage,
-	menu: () => <a href={'#/remotesupport'}><Trans>Remote Support</Trans></a>,
+	menu: Menu,
 	isCommunityProtected: true,
 	additionalProtectedRoutes: [
 		['console', ConsoleView]

--- a/plugins/lime-plugin-remotesupport/remoteSupport.spec.js
+++ b/plugins/lime-plugin-remotesupport/remoteSupport.spec.js
@@ -41,7 +41,7 @@ describe('remote support page', () => {
 		expect(await screen.findByText('Your node has no internet connection')).toBeInTheDocument();
 		expect(await screen.findByText('To enable remote access an internet connection is needed')).toBeInTheDocument();
 		expect(await screen.findByText('You can share your mobile connection to the node by setting up a mobile hotspot')).toBeInTheDocument();
-		expect(await screen.findByRole('button', {name: 'Setup Hotspot'}));
+		expect(await screen.findByRole('button', {name: 'Setup Hotspot'})).toBeInTheDocument();
 	});
 
 	it('redirects to hostpot page when clicking on Setup Hotspot button', async () => {

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportApi.spec.js
@@ -74,24 +74,17 @@ describe('openSession', () => {
     })
 
     it('rejects to api call error on error', async () => {
-        api.call.mockImplementationOnce(() => Promise.reject('timeout'));
-        api.call.mockImplementationOnce(async () => ({'status': 'ok'}));
+        api.call.mockImplementationOnce(async () => Promise.reject('timeout'));
+        api.call.mockImplementationOnce(async () => ({status: 'ok'}));
         expect.assertions(1);
-        try {
-            await openSession()
-        } catch (e) {
-            expect(e).toEqual('timeout')
-        }
+        await expect(openSession()).rejects.toEqual('timeout');
     })
 
     it('calls close session when rejected ', async () => {
         api.call.mockImplementationOnce(() => Promise.reject('timeout'));
-        api.call.mockImplementationOnce(async () => ({'status': 'ok'}));
-        expect.assertions(1);
-        try {
-            await openSession()
-        } catch (e) {
-            expect(api.call).toBeCalledWith('tmate', 'close_session', {})
-        }
+        api.call.mockImplementationOnce(async () => ({status: 'ok'}));
+        expect.assertions(2);
+        await expect(openSession()).rejects.toEqual('timeout');
+        expect(api.call).toBeCalledWith('tmate', 'close_session', {});
     })
 });

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportMenu.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportMenu.js
@@ -1,0 +1,6 @@
+import { h } from "preact";
+import { Trans } from "@lingui/macro";
+
+const Menu = () => <a href={'#/remotesupport'}><Trans>Remote Support</Trans></a>
+
+export default Menu;

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportPage.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportPage.js
@@ -52,7 +52,7 @@ export const WithoutInternet_ = () =>
 		</div>
 	)
 
-export const RemoteSupportPage_ = ({session, hasInternet, openError=false, isSubmitting=false, onOpenSession, onCloseSession, onShowConsole}) =>
+export const RemoteSupportPage_ = ({session, openError=false, isSubmitting=false, onOpenSession, onCloseSession, onShowConsole}) =>
 	<div class="d-flex flex-grow-1 flex-column container container-padded">
 		<h4><Trans>Ask for remote support</Trans></h4>
 		{!session &&

--- a/plugins/lime-plugin-rx/src/rxPage.js
+++ b/plugins/lime-plugin-rx/src/rxPage.js
@@ -138,7 +138,7 @@ export const Page = ({ getNodeStatusTimer, getNodeStatus, stopTimer, isLoading, 
 		getNodeStatusTimer();
 		getNodeStatus();
 		return stopTimer;
-	},[]);
+	},[getNodeStatusTimer, getNodeStatus, stopTimer]);
 
 	return (
 		<div className="container container-padded" >

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -12,7 +12,7 @@ export const MaxLengthMsg = ({ length }) => (
 );
 
 export const MaxLengthErrorMsg = ({ length }) =>
-    <ErrorMsg><MaxLengthMsg length={length}/></ErrorMsg>
+    <ErrorMsg><MaxLengthMsg length={length} /></ErrorMsg>
 
 export const RequiredMsg = () =>
     <Trans>Required</Trans>

--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -3,27 +3,27 @@ import style from "./style.less";
 import { useToggle } from 'react-use';
 
 const Help = ({ Content }) => {
-	const [shown, toggleShown] = useToggle(false);
-	return (
-		<div>
-			<div class={style.symbol} onClick={toggleShown} aria-label="help">
+    const [shown, toggleShown] = useToggle(false);
+    return (
+        <div>
+            <div class={style.symbol} onClick={toggleShown} aria-label="help">
                 ?
-			</div>
-			{shown && <div class={style.background} />}
-			{shown &&
+            </div>
+            {shown && <div class={style.background} />}
+            {shown &&
                 <div class={style.tooltipWrapper} onClick={toggleShown}>
-                	<div class={`${style.tooltip} d-flex flex-column`}
-	onClick={e => e.stopPropagation()}
-                	>
-                		<div class="d-flex flex-grow-1">
-                			<div class={style.tooltipX} onClick={toggleShown}>X</div>
-                		</div>
-                		<Content />
-                	</div>
+                    <div class={`${style.tooltip} d-flex flex-column`}
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <div class="d-flex flex-grow-1">
+                            <div class={style.tooltipX} onClick={toggleShown}>X</div>
+                        </div>
+                        <Content />
+                    </div>
                 </div>
-			}
-		</div>
-	)
+            }
+        </div>
+    )
 }
 
 export default Help;

--- a/src/components/loading/index.js
+++ b/src/components/loading/index.js
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import style from './style.less';
 
 export const Loading = ({ color }) => {
-	const styleOverride = color ? { 'backgroundColor': color } : '';
+	const styleOverride = color ? { backgroundColor: color } : '';
 	return (
 		<div className={style.spinner} aria-label="loading" data-testid="loading">
 			<div className={style.bounce1} style={styleOverride} />

--- a/src/containers/Menu/menu.js
+++ b/src/containers/Menu/menu.js
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-
+import { Trans } from '@lingui/macro';
 import { plugins } from '../../config';
 import { useState } from 'preact/hooks';
 import style from './style.less';

--- a/src/utils/isValidHostname.js
+++ b/src/utils/isValidHostname.js
@@ -1,5 +1,5 @@
 export const isValidHostname = (text = '', length = false) => {
-	const reg = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
+	const reg = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
 	if (length) {
 		return reg.test(text) && text.length > 2;
 	}

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -17,7 +17,7 @@ export const loadEpics = (plugins) => plugins
 	.filter(x => x.store)
 	.filter(plugin => typeof plugin.store.epics !== 'undefined')
 	.map(x => x.store.epics)
-	.map(data => Object.keys(data).map((key, index) => data[key]).reduce((x,y) => x.concat(y), []))
+	.map(data => Object.keys(data).map((key) => data[key]).reduce((x,y) => x.concat(y), []))
 	.reduce((a,b) => a.concat(b), []);
 
 export const loadSelectors = (plugins) => simpleLoader('selector',plugins);

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -1,6 +1,6 @@
 import api from './uhttpd.service';
 import {
-	getBatHost, getBoardData, getSession, getCommunitySettings, getCommunityName,
+	getBatHost, getBoardData, getSession, getCommunitySettings,
 	reboot, checkInternet
 } from './api';
 import { DEFAULT_COMMUNITY_SETTINGS } from './constants';

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -4,7 +4,7 @@ export const dateToLocalUnixTimestamp = (date, time) => {
     // param date: is like '2021-11-24'
     // param time: is like '23:59'
     // return: unix-timestamp
-    const utcDate = new Date(date + `T${time}:00.000Z`);
+    const utcDate = new Date(`${date  }T${time}:00.000Z`);
     const utcTimestamp = utcDate.getTime();
 	const utcOffset = utcDate.getTimezoneOffset() * 60 * 1000;
     const localTimestamp = utcTimestamp + utcOffset;

--- a/src/utils/uhttpd.service.spec.js
+++ b/src/utils/uhttpd.service.spec.js
@@ -50,11 +50,8 @@ describe('uhttpd.service', () => {
 			result: [0, { status: "error", message: "Invalid Firmware"}]
 		}));
 		expect.assertions(1);
-		try {
-			await api.call('lime-utils-admin', 'firmware_upgrade', {fw_path: '/tmp/firmware'});
-		}
-		catch (e) {
-			expect(e).toEqual('Invalid Firmware');
-		}
+		await expect(
+			api.call('lime-utils-admin', 'firmware_upgrade', {fw_path: '/tmp/firmware'})
+		).rejects.toEqual('Invalid Firmware');
 	});
 });


### PR DESCRIPTION
This PR:
- Removes eslint rules from "synacor" which provided many "formatting rules". 
- Keeps only those "code quality" rules. (non used vars, useEffect dependencies, etc).  
- Fixes all left eslint issues (except those of lime-plugin-fbw, to avoid merge conflicts with upcoming PR).
- Add a pre-commit hook to lint staged files.

 @selankon, could you give it a try?
 