### PR TITLE
Add icons to menu

### DIFF
--- a/plugins/lime-plugin-align/src/alignMenu.js
+++ b/plugins/lime-plugin-align/src/alignMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const AlignMenu = () => (
-	<a href={'#/align'}><Trans>Align</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M3.219 9.318c1.155-1.4 2.698-2.161 4.281-2.161v-1c-1.917 0-3.732.924-5.052 2.525l.771.636zM7.5 7.157c1.583 0 3.126.762 4.281 2.161l.771-.636C11.232 7.08 9.417 6.157 7.5 6.157v1zM.886 6.318C2.659 4.168 5.042 2.985 7.5 2.985v-1c-2.793 0-5.446 1.346-7.386 3.697l.772.636zM7.5 2.985c2.458 0 4.84 1.183 6.614 3.333l.772-.636C12.946 3.33 10.293 1.985 7.5 1.985v1zM7.5 12a.5.5 0 01-.5-.5H6A1.5 1.5 0 007.5 13v-1zm.5-.5a.5.5 0 01-.5.5v1A1.5 1.5 0 009 11.5H8zm-.5-.5a.5.5 0 01.5.5h1A1.5 1.5 0 007.5 10v1zm0-1A1.5 1.5 0 006 11.5h1a.5.5 0 01.5-.5v-1z" fill="currentColor" /></svg>
+		<a href={'#/align'}><Trans>Align</Trans></a>
+	</span>
 );

--- a/plugins/lime-plugin-changeNode/src/changeNodeMenu.js
+++ b/plugins/lime-plugin-changeNode/src/changeNodeMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const ChangeNodeMenu = () => (
-	<a href={'#/changenode'}><Trans>Visit a neighboring node</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M1.5 10.5V10H1v.5h.5zm12 0h.5V10h-.5v.5zm0 5v.5h.5v-.5h-.5zm-12 0H1v.5h.5v-.5zm1.72-8.339C4.373 5.761 5.916 5 7.5 5V4c-1.917 0-3.732.924-5.052 2.525l.771.636zM7.5 5c1.583 0 3.126.762 4.281 2.161l.771-.636C11.232 4.924 9.417 4 7.5 4v1zm-6.614.318C2.659 3.168 5.042 1.985 7.5 1.985v-1C4.707.985 2.054 2.331.114 4.682l.772.636zM7.5 1.985c2.458 0 4.84 1.183 6.614 3.333l.772-.636C12.946 2.33 10.293.985 7.5.985v1zM7 7v3h1V7H7zm-5.5 4h12v-1h-12v1zm11.5-.5v5h1v-5h-1zm.5 4.5h-12v1h12v-1zM2 15.5v-5H1v5h1z" fill="currentColor" /></svg>
+		<a href={'#/changenode'}><Trans>Visit a neighboring node</Trans></a>
+	</span>
 );

--- a/plugins/lime-plugin-firmware/src/firmwareMenu.js
+++ b/plugins/lime-plugin-firmware/src/firmwareMenu.js
@@ -1,3 +1,7 @@
-import {h} from 'preact';
+import { h } from 'preact';
 import { Trans } from '@lingui/macro';
-export const Menu = () => <a href={'#/firmware'}><Trans>Firmware</Trans></a>;
+export const Menu = () => (
+    <span>
+        <svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M9.146 6.854l.354.353.707-.707-.353-.354-.708.708zM7.5 4.5l.354-.354-.354-.353-.354.353.354.354zM5.146 6.146l-.353.354.707.707.354-.353-.708-.708zM14.5 7.5H14h.5zm-7 7V14v.5zm0-14V0v.5zm-7 7H0h.5zm9.354-1.354l-2-2-.708.708 2 2 .708-.708zm-2.708-2l-2 2 .708.708 2-2-.708-.708zM7 4.5V11h1V4.5H7zm7 3A6.5 6.5 0 017.5 14v1A7.5 7.5 0 0015 7.5h-1zM7.5 1A6.5 6.5 0 0114 7.5h1A7.5 7.5 0 007.5 0v1zM1 7.5A6.5 6.5 0 017.5 1V0A7.5 7.5 0 000 7.5h1zm-1 0A7.5 7.5 0 007.5 15v-1A6.5 6.5 0 011 7.5H0z" fill="currentColor" /></svg>
+        <a href={'#/firmware'}><Trans>Firmware</Trans></a>
+    </span>);

--- a/plugins/lime-plugin-metrics/src/metricsMenu.js
+++ b/plugins/lime-plugin-metrics/src/metricsMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const MetricsMenu = () => (
-	<a href={'#/metrics'}><Trans>Metrics</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M.5 0v14.5H15M8.5 0v3.5m-5 6V12m0-8v1.5m10-1.5v2.5m0 4V13m-11-7.5h2v4h-2v-4zm5-2h2v4h-2v-4zm5 3h2v4h-2v-4z" stroke="currentColor" /></svg>
+		<a href={'#/metrics'}><Trans>Metrics</Trans></a>
+	</span>
 );

--- a/plugins/lime-plugin-network-admin/src/netAdminMenu.js
+++ b/plugins/lime-plugin-network-admin/src/netAdminMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const NetAdminMenu = () => (
-	<a href='#/netadmin'><Trans>Network Configuration</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M4.5 6.5v-3a3 3 0 016 0v3m-8 0h10a1 1 0 011 1v6a1 1 0 01-1 1h-10a1 1 0 01-1-1v-6a1 1 0 011-1z" stroke="currentColor" /></svg>
+		<a href='#/netadmin'><Trans>Shared Password</Trans></a>
+	</span>
 );

--- a/plugins/lime-plugin-node-admin/src/nodeAdminMenu.js
+++ b/plugins/lime-plugin-node-admin/src/nodeAdminMenu.js
@@ -2,7 +2,10 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 const Menu = () => (
-	<a href={'/nodeadmin'}><Trans>Node Configuration</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path clip-rule="evenodd" d="M5.944.5l-.086.437-.329 1.598a5.52 5.52 0 00-1.434.823L2.487 2.82l-.432-.133-.224.385L.724 4.923.5 5.31l.328.287 1.244 1.058c-.045.277-.103.55-.103.841 0 .291.058.565.103.842L.828 9.395.5 9.682l.224.386 1.107 1.85.224.387.432-.135 1.608-.537c.431.338.908.622 1.434.823l.329 1.598.086.437h3.111l.087-.437.328-1.598a5.524 5.524 0 001.434-.823l1.608.537.432.135.225-.386 1.106-1.851.225-.386-.329-.287-1.244-1.058c.046-.277.103-.55.103-.842 0-.29-.057-.564-.103-.841l1.244-1.058.329-.287-.225-.386-1.106-1.85-.225-.386-.432.134-1.608.537a5.52 5.52 0 00-1.434-.823L9.142.937 9.055.5H5.944z" stroke="currentColor" stroke-linecap="square" stroke-linejoin="round" /><path clip-rule="evenodd" d="M9.5 7.495a2 2 0 01-4 0 2 2 0 014 0z" stroke="currentColor" stroke-linecap="square" stroke-linejoin="round" /></svg>
+		<a href={'/nodeadmin'}><Trans>Node Configuration</Trans></a>
+	</span>
 );
 
 export default Menu;

--- a/plugins/lime-plugin-notes/src/notesMenu.js
+++ b/plugins/lime-plugin-notes/src/notesMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const Menu = () => (
-	<a href={'#/notes'}><Trans>Notes</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M4.5 6.995H4v1h.5v-1zm6 1h.5v-1h-.5v1zm-6 1.998H4v1h.5v-1zm6 1.007h.5v-1h-.5v1zm-6-7.003H4v1h.5v-1zM8.5 5H9V4h-.5v1zm2-4.5l.354-.354L10.707 0H10.5v.5zm3 3h.5v-.207l-.146-.147-.354.354zm-9 4.495h6v-1h-6v1zm0 2.998l6 .007v-1l-6-.007v1zm0-5.996L8.5 5V4l-4-.003v1zm8 9.003h-10v1h10v-1zM2 13.5v-12H1v12h1zM2.5 1h8V0h-8v1zM13 3.5v10h1v-10h-1zM10.146.854l3 3 .708-.708-3-3-.708.708zM2.5 14a.5.5 0 01-.5-.5H1A1.5 1.5 0 002.5 15v-1zm10 1a1.5 1.5 0 001.5-1.5h-1a.5.5 0 01-.5.5v1zM2 1.5a.5.5 0 01.5-.5V0A1.5 1.5 0 001 1.5h1z" fill="currentColor" /></svg>
+		<a href={'#/notes'}><Trans>Notes</Trans></a>
+	</span>
 );

--- a/plugins/lime-plugin-pirania/src/piraniaMenu.js
+++ b/plugins/lime-plugin-pirania/src/piraniaMenu.js
@@ -2,6 +2,9 @@ import { h } from "preact";
 import { Trans } from '@lingui/macro';
 
 const PiraniaMenu = () =>
-    <a href={'#/access'}><Trans>Access Vouchers</Trans></a>
+    <span>
+        <svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M1.5.5V0a.5.5 0 00-.5.5h.5zm12 0h.5a.5.5 0 00-.5-.5v.5zm0 14l-.224.447A.5.5 0 0014 14.5h-.5zm-2-1l.224-.447a.5.5 0 00-.448 0l.224.447zm-2 1l-.224.447a.5.5 0 00.448 0L9.5 14.5zm-2-1l.224-.447a.5.5 0 00-.448 0l.224.447zm-2 1l-.224.447a.5.5 0 00.448 0L5.5 14.5zm-4 0H1a.5.5 0 00.724.447L1.5 14.5zm2-1l.224-.447a.5.5 0 00-.448 0l.224.447zM1.5 1h12V0h-12v1zM13 .5v14h1V.5h-1zm.724 13.553l-2-1-.448.894 2 1 .448-.894zm-2.448-1l-2 1 .448.894 2-1-.448-.894zm-1.552 1l-2-1-.448.894 2 1 .448-.894zm-2.448-1l-2 1 .448.894 2-1-.448-.894zM2 14.5V.5H1v14h1zm3.724-.447l-2-1-.448.894 2 1 .448-.894zm-2.448-1l-2 1 .448.894 2-1-.448-.894zM4 5h2V4H4v1zm4 0h3V4H8v1zM4 8h2V7H4v1zm4 0h3V7H8v1zm0 3h3v-1H8v1z" fill="currentColor" /></svg>
+        <a href={'#/access'}><Trans>Access Vouchers</Trans></a>
+    </span>
 
 export default PiraniaMenu;

--- a/plugins/lime-plugin-remotesupport/src/remoteSupportMenu.js
+++ b/plugins/lime-plugin-remotesupport/src/remoteSupportMenu.js
@@ -1,6 +1,9 @@
 import { h } from "preact";
 import { Trans } from "@lingui/macro";
 
-const Menu = () => <a href={'#/remotesupport'}><Trans>Remote Support</Trans></a>
+const Menu = () => <span>
+    <svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M10.329 10.328a4 4 0 01-5.657 0m5.657 0a4 4 0 000-5.656m0 5.656l2.12 2.122m-7.777-2.122a4 4 0 010-5.656m0 5.656L2.55 12.45m7.779-7.778a4 4 0 00-5.657 0m5.657 0l2.12-2.122M4.673 4.672L2.55 2.55m9.9 9.9a7 7 0 01-9.9 0m9.9 0a7 7 0 000-9.9m-9.9 9.9a7 7 0 010-9.9m9.9 0a7 7 0 00-9.9 0" stroke="currentColor" /></svg>
+    <a href={'#/remotesupport'}><Trans>Remote Support</Trans></a>
+</span>
 
 export default Menu;

--- a/plugins/lime-plugin-rx/src/rxMenu.js
+++ b/plugins/lime-plugin-rx/src/rxMenu.js
@@ -3,5 +3,8 @@ import { h } from 'preact';
 import { Trans } from '@lingui/macro';
 
 export const RxMenu = () => (
-	<a href={'#/rx'}><Trans>Status</Trans></a>
+	<span>
+		<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" width="15" height="15"><path d="M5.5.5h-4a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1v-4a1 1 0 00-1-1zm8 0h-4a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1v-4a1 1 0 00-1-1zm0 8h-4a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1v-4a1 1 0 00-1-1zm-8 0h-4a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1v-4a1 1 0 00-1-1z" stroke="currentColor" /></svg>
+		<a href={'#/rx'}><Trans>Status</Trans></a>
+	</span>
 );

--- a/src/containers/Menu/style.less
+++ b/src/containers/Menu/style.less
@@ -13,6 +13,11 @@
 	z-index: 9999;
 	nav {
         padding-top: 20px;
+        span {
+            padding: 10px 0 10px 30px;
+            display: flex;
+            align-items: center;
+        }
 		a {
 			display: block;
 			padding: 10px 0 10px 30px;


### PR DESCRIPTION
During many implementations with communities with low-literacy levels, I missed having visual cues to point too where certain actions can be performed. So I've added some icons from [teenyicons.com](https://teenyicons.com/) which can help with that.

![image](https://user-images.githubusercontent.com/693728/198752045-c80ceefd-9532-4450-8b00-c7c22b37292c.png)
