### PR TITLE
Add gh action to upload artifacts

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,9 +17,3 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build:production"
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-            name: build-artifacts
-            path: build/

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,3 +17,9 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build:production"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: build-artifacts
+            path: build/

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,4 +1,4 @@
-name: CI-Development
+name: Test build
 
 on: [pull_request]
 

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -21,8 +21,13 @@ jobs:
           with:
             build-script: "build:production"
 
+        # Used to send a comment to the PR with the artifact url
+        - name: Save PR number
+          run: |
+           echo ${{ github.event.number }} > ./build/NR
+
         - name: Upload build artifacts
           uses: actions/upload-artifact@v4
           with:
-            name: build-artifacts
+            name: limeAppBuild-${{ github.event.number }}
             path: build/

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -24,10 +24,11 @@ jobs:
         # Used to send a comment to the PR with the artifact url
         - name: Save PR number
           run: |
-           echo ${{ github.event.number }} > ./build/NR
+              mkdir -p build/pr_number/
+              touch build/pr_number/${{ github.event.number }}
 
         - name: Upload build artifacts
           uses: actions/upload-artifact@v4
           with:
-            name: limeAppBuild-${{ github.event.number }}
+            name: limeAppBuild
             path: build/

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -1,4 +1,4 @@
-name: CI-Development
+name: Publish artifacts
 
 on:
     pull_request:

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -2,28 +2,27 @@ name: Publish artifacts
 
 on:
     pull_request:
-        types:
-            - labeled
+        types: [ labeled ]
 
 jobs:
-  build-artifacts:
-    if: contains(github.event.pull_request.labels.*.name, 'artifact')
-    runs-on: ubuntu-latest
+    build-artifacts:
+        if: ${{ github.event.label.name == 'artifact' }}
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
+        steps:
+        - uses: actions/checkout@v3
 
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
+        - name: Install node
+          uses: actions/setup-node@v3
+          with:
             node-version: 16
 
-      - uses: preactjs/compressed-size-action@v2
-        with:
-          build-script: "build:production"
+        - uses: preactjs/compressed-size-action@v2
+          with:
+            build-script: "build:production"
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
+        - name: Upload build artifacts
+          uses: actions/upload-artifact@v4
+          with:
             name: build-artifacts
             path: build/

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -1,0 +1,54 @@
+name: CI-Development
+
+on:
+    pull_request:
+        types:
+            - labeled
+
+jobs:
+  build-artifacts:
+    if: contains(github.event.pull_request.labels.*.name, 'artifact')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find a PR comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: 'Artifacts deployed: '
+      -   name: Delete Comment
+          uses: actions/github-script@v6
+          continue-on-error: true
+          if: steps.fc.outputs.comment-id != 0
+          with:
+              script: |
+                  github.rest.issues.deleteComment({
+                    comment_id: ${{ steps.fc.outputs.comment-id }},
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  })
+
+      - uses: actions/checkout@v3
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+            node-version: 16
+
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build:production"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: build-artifacts
+            path: build/
+
+      - name: Update the PR comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+            issue-number: ${{ github.event.pull_request.number }}
+            body: |
+                Artifacts deployed:  ${{ steps.artifact-upload-step.outputs.artifact-url }}

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -2,11 +2,11 @@ name: Publish artifacts
 
 on:
     pull_request:
-        types: [ labeled ]
+        types: [ labeled, synchronize ]
 
 jobs:
     build-artifacts:
-        if: ${{ github.event.label.name == 'artifact' }}
+        if: contains(github.event.pull_request.labels.*.name, 'artifact')
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -11,24 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Find a PR comment
-        uses: peter-evans/find-comment@v2
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: 'Artifacts deployed: '
-      -   name: Delete Comment
-          uses: actions/github-script@v6
-          continue-on-error: true
-          if: steps.fc.outputs.comment-id != 0
-          with:
-              script: |
-                  github.rest.issues.deleteComment({
-                    comment_id: ${{ steps.fc.outputs.comment-id }},
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                  })
-
       - uses: actions/checkout@v3
 
       - name: Install node
@@ -45,10 +27,3 @@ jobs:
         with:
             name: build-artifacts
             path: build/
-
-      - name: Update the PR comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-            issue-number: ${{ github.event.pull_request.number }}
-            body: |
-                Artifacts deployed:  ${{ steps.artifact-upload-step.outputs.artifact-url }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Node.js CI
+name: Run tests
 
 on:
   push:


### PR DESCRIPTION
FTR 

Limeapp automatic preview builds.

Now when a PR is marked with the Labels "artifact", an additional GH action will run to upload a built version of the limeapp on GH.

This artifact will store the PR number, to on posterior publish a GH comment on the PR with the artifacts url. 

Example:

https://github.com/libremesh/lime-app/pull/398#issuecomment-1939264412

The github action to publish the comment runs on the develop branch and not on the pr to protect from external forks PR's the secrets and other configurations (to comment on the PR the action needs write and read permissions, which are dangerous to give to a fork from an external repository). 

Further reading

Keeping your GitHub Actions and workflows secure 

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

https://glasnt.com/blog/pull_request_target_labels/


Workflow run docs

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run