### PR TITLE
Implement mesh node safe reboot

### DIFF
--- a/plugins/lime-plugin-mesh-wide-upgrade/src/components/upgradeState/ParallelErrors.tsx
+++ b/plugins/lime-plugin-mesh-wide-upgrade/src/components/upgradeState/ParallelErrors.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/macro";
 
 import { StatusMessage } from "components/status/statusMessage";
 
-import { ParallelMutationError, SyncCallErrors } from "utils/meshWideSyncCall";
+import { RemoteNodeCallError, SyncCallErrors } from "utils/meshWideSyncCall";
 
 export const ParallelErrors = ({ errors }: { errors: SyncCallErrors }) => {
     return (
@@ -13,7 +13,7 @@ export const ParallelErrors = ({ errors }: { errors: SyncCallErrors }) => {
             </StatusMessage>
             <div className={"flex flex-col gap-3 mt-4 overflow-auto gap-4"}>
                 {errors.map((error, key) => {
-                    if (error instanceof ParallelMutationError) {
+                    if (error instanceof RemoteNodeCallError) {
                         return (
                             <div key={key}>
                                 <strong>{error.ip}</strong>: {error.message}

--- a/plugins/lime-plugin-mesh-wide-upgrade/src/utils/api.ts
+++ b/plugins/lime-plugin-mesh-wide-upgrade/src/utils/api.ts
@@ -1,29 +1,12 @@
 import {
     MeshUpgradeApiErrorTypes,
-    MeshWideRPCReturnTypes,
     MeshWideUpgradeInfo,
     UpgradeStatusType,
 } from "plugins/lime-plugin-mesh-wide-upgrade/src/meshUpgradeTypes";
 
-import { ParallelMutationError } from "utils/meshWideSyncCall";
+import { RemoteNodeCallError } from "utils/meshWideSyncCall";
 import { login } from "utils/queries";
-import api, { UhttpdService } from "utils/uhttpd.service";
-
-export const meshUpgradeApiCall = async (
-    method: string,
-    customApi?: UhttpdService
-) => {
-    const httpService = customApi || api;
-    const res = (await httpService.call(
-        "lime-mesh-upgrade",
-        method,
-        {}
-    )) as MeshWideRPCReturnTypes;
-    if (res.error) {
-        throw new MeshUpgradeApiError(res.error, res.code);
-    }
-    return res.code;
-};
+import { UhttpdService } from "utils/uhttpd.service";
 
 export class MeshUpgradeApiError extends Error {
     message: string;
@@ -34,45 +17,6 @@ export class MeshUpgradeApiError extends Error {
         this.message = message;
         this.code = code;
         Object.setPrototypeOf(this, MeshUpgradeApiError.prototype);
-    }
-}
-
-/**
- * Wrapper that tries to call a remote node and returns the result or throws an error
- *
- * First it tries to login and if success do a specific call to the remote node
- * @param ip
- * @param apiMethod
- */
-export async function callToRemoteNode({
-    ip,
-    apiMethod,
-}: {
-    ip: string;
-    apiMethod: string;
-}) {
-    const customApi = new UhttpdService(ip);
-    try {
-        await login({ username: "lime-app", password: "generic", customApi });
-    } catch (error) {
-        throw new ParallelMutationError(
-            `Cannot login`,
-            customApi.customIp,
-            error
-        );
-    }
-    try {
-        return await meshUpgradeApiCall(apiMethod, customApi);
-    } catch (error) {
-        let additionalInfo = "";
-        if (error instanceof MeshUpgradeApiError) {
-            additionalInfo = `: ${error.message}`;
-        }
-        throw new ParallelMutationError(
-            `Cannot startSafeUpgrade${additionalInfo}`,
-            ip,
-            error
-        );
     }
 }
 
@@ -96,3 +40,46 @@ export const getNodeIpsByStatus = (
         )
         .map((node) => node.node_ip as string); // 'as string' is safe here due to the filter condition
 };
+
+/**
+ * Wrapper to do calls to a remote node and returns the result or throws an error
+ *
+ * First it tries to login and if success do a specific call to the remote node
+ * @param ip
+ * @param apiMethod
+ */
+export async function callToRemoteNode<T>({
+    ip,
+    apiCall,
+    username = "lime-app",
+    password = "generic",
+}: {
+    ip: string;
+    apiCall: (customApi: UhttpdService) => Promise<T>;
+    username?: string;
+    password?: string;
+}) {
+    const customApi = new UhttpdService(ip);
+    try {
+        await login({ username, password, customApi });
+    } catch (error) {
+        throw new RemoteNodeCallError(
+            `Cannot login`,
+            customApi.customIp,
+            error
+        );
+    }
+    try {
+        return await apiCall(customApi);
+    } catch (error) {
+        let additionalInfo = "";
+        if (error instanceof MeshUpgradeApiError) {
+            additionalInfo = `: ${error.message}`;
+        }
+        throw new RemoteNodeCallError(
+            `Cannot do remote call${additionalInfo}`,
+            ip,
+            error
+        );
+    }
+}

--- a/plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/NodeDetail.tsx
+++ b/plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/NodeDetail.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/macro";
 
 import { StatusAndButton } from "plugins/lime-plugin-mesh-wide/src/components/Components";
+import RemoteRebootBtn from "plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/RebootNodeBtn";
 import { useSetReferenceState } from "plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/SetReferenceStateBtn";
 import {
     Row,
@@ -39,10 +40,7 @@ const NodeDetails = ({ actual, reference, name }: NodeMapFeature) => {
         <div>
             <Row>
                 <div className={"text-3xl"}>{name}</div>
-                {/*todo(kon): implement safe_reboot*/}
-                {/*<Button color={"danger"} outline={true} size={"sm"}>*/}
-                {/*    <PowerIcon />*/}
-                {/*</Button>*/}
+                <RemoteRebootBtn node={nodeToShow} />
             </Row>
             <Row>
                 {!isDown ? (

--- a/plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/RebootNodeBtn.tsx
+++ b/plugins/lime-plugin-mesh-wide/src/components/FeatureDetail/RebootNodeBtn.tsx
@@ -1,0 +1,124 @@
+import { Trans } from "@lingui/macro";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "preact/hooks";
+import { useCallback } from "react";
+
+import { useModal } from "components/Modal/Modal";
+import { Button } from "components/buttons/button";
+import { ErrorMsg } from "components/form";
+import Loading from "components/loading";
+
+import { callToRemoteNode } from "plugins/lime-plugin-mesh-wide-upgrade/src/utils/api";
+import { PowerIcon } from "plugins/lime-plugin-mesh-wide/src/icons/power";
+import { INodeInfo } from "plugins/lime-plugin-mesh-wide/src/meshWideTypes";
+
+interface IRemoteRebotProps {
+    ip: string;
+    password: string;
+}
+
+export async function remoteReboot({ ip, password }: IRemoteRebotProps) {
+    return await callToRemoteNode({
+        ip,
+        apiCall: (customApi) =>
+            customApi.call("system", "reboot", {}).then(() => true),
+        username: "root",
+        password,
+    });
+}
+
+const useRemoteReboot = (opts?) => {
+    return useMutation((props: IRemoteRebotProps) => remoteReboot(props), {
+        mutationKey: ["system", "reboot"],
+        ...opts,
+    });
+};
+
+const useRebootNodeModal = ({ node }: { node: INodeInfo }) => {
+    const { toggleModal, setModalState, isModalOpen } = useModal();
+    const [password, setPassword] = useState("");
+    const { mutate, isLoading, error } = useRemoteReboot({
+        onSuccess: () => {
+            toggleModal();
+        },
+    });
+
+    function changePassword(e) {
+        setPassword(e.target.value || "");
+    }
+
+    const doLogin = useCallback(() => {
+        mutate({ ip: node.ipv4, password });
+    }, [mutate, node.ipv4, password]);
+
+    const updateModalState = useCallback(() => {
+        setModalState({
+            title: <Trans>Reboot node {node.hostname}</Trans>,
+            content: (
+                <div>
+                    <Trans>
+                        Are you sure you want to reboot this node? This action
+                        will disconnect the node from the network for a few
+                        minutes. <br />
+                        Add shared password or let it empty if no password is
+                        set.
+                    </Trans>
+                    {isLoading && <Loading />}
+                    {!isLoading && (
+                        <div className={"mt-4"}>
+                            <label htmlFor={"password"}>Node password</label>
+                            <input
+                                type="password"
+                                id={"password"}
+                                value={password}
+                                onInput={changePassword}
+                            />
+                            {error && (
+                                <ErrorMsg>
+                                    <Trans>
+                                        Error performing reboot: {error}
+                                    </Trans>
+                                </ErrorMsg>
+                            )}
+                        </div>
+                    )}
+                </div>
+            ),
+            successCb: doLogin,
+            successBtnText: <Trans>Reboot</Trans>,
+        });
+    }, [doLogin, error, isLoading, node.hostname, password, setModalState]);
+
+    const rebootModal = useCallback(() => {
+        updateModalState();
+        toggleModal();
+    }, [toggleModal, updateModalState]);
+
+    // Update modal state with mutation result
+    useEffect(() => {
+        if (isModalOpen) {
+            updateModalState();
+        }
+    }, [isLoading, error, isModalOpen, updateModalState]);
+
+    return { rebootModal, toggleModal, isModalOpen };
+};
+
+const RemoteRebootBtn = ({ node }: { node: INodeInfo }) => {
+    const { rebootModal, isModalOpen } = useRebootNodeModal({
+        node,
+    });
+
+    return (
+        <Button
+            color={"danger"}
+            outline={true}
+            size={"sm"}
+            onClick={() => !isModalOpen && rebootModal()}
+        >
+            <PowerIcon />
+        </Button>
+    );
+};
+
+export default RemoteRebootBtn;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -146,7 +146,7 @@ const Modal = ({
 
                     <div
                         onClick={stopPropagation}
-                        className="flex flex-col px-6 justify-between w-full md:w-10/12 h-96 md:mx-24 self-center bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all "
+                        className="flex flex-col px-6 justify-between w-full min-h-96 md:w-10/12 md:mx-24 self-center bg-white rounded-lg overflow-auto text-left shadow-xl transform transition-all "
                     >
                         <div className="bg-white pt-5 pb-4 sm:p-6 sm:pb-4">
                             <div className="mt-3 text-start sm:mt-0 sm:text-left">

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -88,7 +88,7 @@ const App = () => {
     }, [session, login]);
 
     if (!session?.username || !boardData) {
-        return <div>"Loading..."</div>;
+        return <div>Loading...</div>;
     }
 
     return (

--- a/src/utils/meshWideSyncCall.ts
+++ b/src/utils/meshWideSyncCall.ts
@@ -5,7 +5,7 @@ import { useCallback } from "react";
 import queryCache from "utils/queryCache";
 import { useSharedData } from "utils/useSharedData";
 
-export class ParallelMutationError extends Error {
+export class RemoteNodeCallError extends Error {
     ip: string;
     error: Error;
     constructor(message: string, ip: string, error: Error) {
@@ -15,7 +15,7 @@ export class ParallelMutationError extends Error {
         this.error = error;
 
         // Set the prototype explicitly.
-        Object.setPrototypeOf(this, ParallelMutationError.prototype);
+        Object.setPrototypeOf(this, RemoteNodeCallError.prototype);
     }
 }
 
@@ -24,7 +24,7 @@ interface IMutationFnVariables<TVariables> {
     variables?: TVariables;
 }
 
-export type SyncCallErrors = Array<Error | ParallelMutationError>;
+export type SyncCallErrors = Array<Error | RemoteNodeCallError>;
 type SyncCallResults<TResult> = TResult[];
 /**
  * This object is used to store the results and errors of all the mutations calls.
@@ -49,7 +49,7 @@ interface IMeshWideSyncCall<TVariables, TResult> {
     variables?: TVariables;
     options?: UseMutationOptions<
         TResult,
-        ParallelMutationError,
+        RemoteNodeCallError,
         IMutationFnVariables<TVariables>
     >;
 }
@@ -60,7 +60,7 @@ interface IMeshWideSyncCall<TVariables, TResult> {
  * In order to reuse the data on different parts, it implements caches using the queryCache. The results and errors for
  * all the calls are stored using useSharedData query.
  *
- * In addition, is possible to acces to every single call accesing to the [...mutationKey, ip] key on the queryCache.
+ * In addition, is possible to access to every single call accessing to the [...mutationKey, ip] key on the queryCache.
  *
  * @param mutationKey Mutation key to store the results and errors
  * @param mutationFn Function that will be called for every ip
@@ -81,7 +81,7 @@ export const useMeshWideSyncCall = <TVariables, TResult>({
 
     const { mutateAsync } = useMutation<
         TResult,
-        ParallelMutationError,
+        RemoteNodeCallError,
         IMutationFnVariables<TVariables>
     >({ mutationFn, mutationKey, ...options });
 


### PR DESCRIPTION
Implement a button to remotely perform a safe reboot on a node that is shown on the mesh wide map.

It refactors the code in order to expose a function to do authenticated requests to any node. 

![image](https://github.com/libremesh/lime-app/assets/16777076/d15e3fcb-35bc-4988-8cc2-07276a02b4aa)
![image](https://github.com/libremesh/lime-app/assets/16777076/9c501cf6-ca51-4023-a610-3973b7ce810f)
